### PR TITLE
Migrate to Scala 3

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,20 +1,10 @@
 rules = [
-  RemoveUnused
   DisableSyntax
   LeakingImplicitClassVal
-  ProcedureSyntax
   NoValInForComprehension
-  SortImports
 ]
 
 DisableSyntax.noNulls = true
 DisableSyntax.noThrows = true
 DisableSyntax.noAsInstanceOf = true
 DisableSyntax.noVars = true
-
-SortImports.blocks = [
-  "re:javax?\\.",
-  "akka.",
-  "*",
-  "scala."
-]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,51 +1,44 @@
-version = 3.4.0
-runner.dialect = scala212
+version = 3.7.17
 
-style = defaultWithAlign
-maxColumn = 150
-lineEndings = unix
-importSelectors = singleLine
+runner.dialect = scala3
 
-project {
-  git = true
-}
+preset = default
+maxColumn = 120
+
+align.tokens."+" = [
+  { code = "extends", owner = "(Template|EnumCase|Enum)" }
+  { code = "//",      owner = ".*" }
+  { code = "{",       owner = "Template" }
+  { code = "}",       owner = "Template" }
+  { code = "->",      owner = "Term.ApplyInfix" }
+  { code = "<-",      owner = "Enumerator.Generator" }
+  { code = "%",       owner = "Term.ApplyInfix"},
+  { code = "%%",      owner = "Term.ApplyInfix"}
+  { code = "=",       owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type|Given))" }
+]
+align.openParenDefnSite = true
+align.openParenCallSite = true
 
 docstrings.style = Asterisk
-docstrings.wrap = no
 
-align = most
+danglingParentheses.preset = false
+includeCurlyBraceInSelectChains = false
 
-align {
-  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":" ]
-  arrowEnumeratorGenerator = true
-  openParenCallSite = false
-  openParenDefnSite = false
-}
+newlines.avoidAfterYield = false
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
 
-binPack {
-  parentConstructors = false
-}
+rewrite.rules = [SortImports, RedundantBraces, RedundantParens, PreferCurlyFors]
 
-continuationIndent {
-  callSite = 2
-  defnSite = 2
-}
+project.git = true
+lineEndings = preserve
 
-newlines {
-  penalizeSingleSelectMultiArgList = false
-  sometimesBeforeColonInMethodReturnType = true
-}
+spaces.beforeContextBoundColon = true
 
-rewrite {
-  rules = [RedundantBraces, RedundantParens, AsciiSortImports]
-  redundantBraces {
-    maxLines = 100
-    includeUnitMethods = true
-    stringInterpolation = true
+fileOverride {
+  "glob:**/project/*.scala" {
+    runner.dialect = scala212source3
   }
-}
-
-spaces {
-  inImportCurlyBraces = false
-  beforeContextBoundColon = false
+  "glob:**/*.sbt" {
+    runner.dialect = scala212source3
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
+import _root_.io.github.davidgregory084.TpolecatPlugin.autoImport.{ScalacOptions, tpolecatScalacOptions}
+
 ThisBuild / organization := "com.tcooling"
 ThisBuild / name := "wordle-scala"
-ThisBuild / scalaVersion := "2.12.15"
-ThisBuild / scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.6.1"
+ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / version := "0.0.1"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
@@ -13,9 +14,9 @@ lazy val wordleScala = Project(id = "wordle-scala", base = file("."))
   .settings(mainClass := Some("com.tcooling.wordle.Main"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % "2.3.0",
-      "org.scalamock" %% "scalamock" % "4.4.0" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.4" % Test
+      "org.typelevel" %% "cats-core" % "2.10.0",
+      "org.scalamock" %% "scalamock" % "4.4.0"  % Test cross CrossVersion.for3Use2_13,
+      "org.scalatest" %% "scalatest" % "3.2.17" % Test
     )
   )
 
@@ -23,20 +24,9 @@ lazy val defaultSettings = Seq(
   Test / parallelExecution := false,
   Test / fork := true,
   scalafmtOnCompile := true,
-  Compile / scalacOptions ++= Seq(
-    "-encoding",
-    "UTF-8",
-    "-deprecation",
-    "-unchecked",
-    "-Ywarn-dead-code",
-    "-Ywarn-unused-import",
-    "-Xfatal-warnings",
-    "-target:jvm-1.8",
-    "-feature",
-    "-language:postfixOps",
-    "-language:implicitConversions",
-    "-language:reflectiveCalls",
-    "-language:higherKinds",
-    "-language:existentials"
+  tpolecatScalacOptions ++= Set(
+    ScalacOptions.other("-no-indent"),
+    ScalacOptions.other("-old-syntax"),
+    ScalacOptions.other("-Wunused:all")
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import _root_.io.github.davidgregory084.TpolecatPlugin.autoImport.{ScalacOptions, tpolecatScalacOptions}
+import _root_.io.github.davidgregory084.TpolecatPlugin.autoImport.{tpolecatScalacOptions, ScalacOptions}
 
 ThisBuild / organization := "com.tcooling"
 ThisBuild / name := "wordle-scala"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ lazy val wordleScala = Project(id = "wordle-scala", base = file("."))
   .settings(
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.10.0",
-      "org.scalamock" %% "scalamock" % "4.4.0"  % Test cross CrossVersion.for3Use2_13,
       "org.scalatest" %% "scalatest" % "3.2.17" % Test
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("org.scalameta"             % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")

--- a/src/main/scala/com/tcooling/wordle/Main.scala
+++ b/src/main/scala/com/tcooling/wordle/Main.scala
@@ -18,6 +18,6 @@ object Main extends App {
     numberOfGuesses = numberOfGuesses
   )
 
-  new Wordle(config, WordsReader, RandomWord.chooseRandomWord, UserInputGuessConnector).startGame()
+  Wordle(config, WordsReader, RandomWord.chooseRandomWord, UserInputGuessConnector).startGame()
 
 }

--- a/src/main/scala/com/tcooling/wordle/Main.scala
+++ b/src/main/scala/com/tcooling/wordle/Main.scala
@@ -8,9 +8,9 @@ import com.tcooling.wordle.util.RandomWord
 
 object Main extends App {
 
-  private val filename:        String = "words.txt"
-  private val wordLength:      Int    = 5
-  private val numberOfGuesses: Int    = 6
+  private val filename: String     = "words.txt"
+  private val wordLength: Int      = 5
+  private val numberOfGuesses: Int = 6
 
   private val config = WordleConfig(
     filename = filename,

--- a/src/main/scala/com/tcooling/wordle/Main.scala
+++ b/src/main/scala/com/tcooling/wordle/Main.scala
@@ -2,15 +2,15 @@ package com.tcooling.wordle
 
 import com.tcooling.wordle.game.Wordle
 import com.tcooling.wordle.input.UserInputGuessConnector
-import com.tcooling.wordle.model.WordleConfig
+import com.tcooling.wordle.model.{Filename, NumberOfGuesses, WordLength, WordleConfig}
 import com.tcooling.wordle.parser.WordsReader
 import com.tcooling.wordle.util.RandomWord
 
 object Main extends App {
 
-  private val filename: String     = "words.txt"
-  private val wordLength: Int      = 5
-  private val numberOfGuesses: Int = 6
+  private val filename: Filename               = Filename.apply("words.txt")
+  private val wordLength: WordLength           = WordLength.apply(5)
+  private val numberOfGuesses: NumberOfGuesses = NumberOfGuesses.apply(6)
 
   private val config = WordleConfig(
     filename = filename,

--- a/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
+++ b/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
@@ -15,7 +15,7 @@ object GameBoard {
    * Generate the game board and put each user guess on the board in the correct colour
    */
   def generateGameBoard(wordLength: Int, numberOfGuesses: Int, previousGuesses: List[WordGuess]): List[String] = {
-    val emptyRow = List.fill(wordLength)(startSeparator + " " + endSeparator)
+    val emptyRow = List.fill(wordLength)(s"$startSeparator $endSeparator")
 
     @tailrec
     def loop(previousGuesses: List[WordGuess], numberOfGuesses: Int, gameBoard: List[String]): List[String] =
@@ -34,7 +34,7 @@ object GameBoard {
    * colour is the letter guess itself, which is between a start and end separator.
    */
   def generateBoardRow(wordGuess: WordGuess): String = wordGuess.letterGuesses.map { letterGuess =>
-    startSeparator + letterGuess.show + endSeparator
+    s"$startSeparator${letterGuess.show}$endSeparator"
   }.mkString
 
 }

--- a/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
+++ b/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
@@ -1,15 +1,13 @@
 package com.tcooling.wordle.game
 
-import cats.implicits.toShow
-import com.tcooling.wordle.model.LetterGuess.showLetterGuess
-import com.tcooling.wordle.model.WordGuess
+import com.tcooling.wordle.model.{boardRow, WordGuess}
 
 import scala.annotation.tailrec
 
 object GameBoard {
 
-  private val startSeparator: Char = '['
-  private val endSeparator:   Char = ']'
+  val startSeparator: Char = '['
+  val endSeparator: Char   = ']'
 
   /**
    * Generate the game board and put each user guess on the board in the correct colour
@@ -22,19 +20,11 @@ object GameBoard {
       if (numberOfGuesses == 0) gameBoard
       else
         previousGuesses match {
-          case head :: tail => loop(tail, numberOfGuesses - 1, gameBoard :+ generateBoardRow(head))
+          case head :: tail => loop(tail, numberOfGuesses - 1, gameBoard :+ head.boardRow)
           case Nil          => loop(Nil, numberOfGuesses - 1, gameBoard :+ emptyRow.mkString)
         }
 
     loop(previousGuesses, numberOfGuesses, gameBoard = Nil)
   }
-
-  /**
-   * Given the [[WordGuess]], create the string to be printed. The only character that is displayed using a console
-   * colour is the letter guess itself, which is between a start and end separator.
-   */
-  def generateBoardRow(wordGuess: WordGuess): String = wordGuess.letterGuesses.map { letterGuess =>
-    s"$startSeparator${letterGuess.show}$endSeparator"
-  }.mkString
 
 }

--- a/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
+++ b/src/main/scala/com/tcooling/wordle/game/GameBoard.scala
@@ -1,6 +1,6 @@
 package com.tcooling.wordle.game
 
-import com.tcooling.wordle.model.{boardRow, WordGuess}
+import com.tcooling.wordle.model.{boardRow, NumberOfGuesses, WordGuess, WordLength}
 
 import scala.annotation.tailrec
 
@@ -12,8 +12,10 @@ object GameBoard {
   /**
    * Generate the game board and put each user guess on the board in the correct colour
    */
-  def generateGameBoard(wordLength: Int, numberOfGuesses: Int, previousGuesses: List[WordGuess]): List[String] = {
-    val emptyRow = List.fill(wordLength)(s"$startSeparator $endSeparator")
+  def generateGameBoard(wordLength: WordLength,
+                        numberOfGuesses: NumberOfGuesses,
+                        previousGuesses: List[WordGuess]): List[String] = {
+    val emptyRow = List.fill(wordLength.value)(s"$startSeparator $endSeparator")
 
     @tailrec
     def loop(previousGuesses: List[WordGuess], numberOfGuesses: Int, gameBoard: List[String]): List[String] =
@@ -24,7 +26,7 @@ object GameBoard {
           case Nil          => loop(Nil, numberOfGuesses - 1, gameBoard :+ emptyRow.mkString)
         }
 
-    loop(previousGuesses, numberOfGuesses, gameBoard = Nil)
+    loop(previousGuesses, numberOfGuesses.value, gameBoard = Nil)
   }
 
 }

--- a/src/main/scala/com/tcooling/wordle/game/Wordle.scala
+++ b/src/main/scala/com/tcooling/wordle/game/Wordle.scala
@@ -11,10 +11,10 @@ import com.tcooling.wordle.parser.{FileReader, WordsParser}
 import scala.annotation.tailrec
 
 final class Wordle(
-  config:         WordleConfig,
-  fileReader:     FileReader,
-  randomWord:     NonEmptySet[String] => String,
-  guessConnector: GuessInputConnector
+    config: WordleConfig,
+    fileReader: FileReader,
+    randomWord: NonEmptySet[String] => String,
+    guessConnector: GuessInputConnector
 ) {
 
   def startGame(): Unit =
@@ -27,10 +27,10 @@ final class Wordle(
     }
 
   private def gameLoop(
-    config:         WordleConfig,
-    targetWord:     String,
-    allWords:       NonEmptySet[String],
-    guessConnector: GuessInputConnector
+      config: WordleConfig,
+      targetWord: String,
+      allWords: NonEmptySet[String],
+      guessConnector: GuessInputConnector
   ): Unit = {
     val nextStateF: (FSM, List[WordGuess]) => (FSM, List[WordGuess]) =
       WordleFSM.nextState(config, targetWord, allWords, guessConnector)(_, _)

--- a/src/main/scala/com/tcooling/wordle/game/Wordle.scala
+++ b/src/main/scala/com/tcooling/wordle/game/Wordle.scala
@@ -21,7 +21,8 @@ final class Wordle(
     WordsParser.apply(config.filename, config.wordLength, fileReader).parseWords match {
       case Left(error) => printError(error)
       case Right(allWords) =>
-        println(s"Successfully parsed ${config.filename}, read ${allWords.length} words of length ${config.wordLength}")
+        println(
+          s"Successfully parsed ${config.filename}, read ${allWords.length} words of length ${config.wordLength.value}")
         val targetWord = randomWord(allWords)
         gameLoop(config, targetWord, allWords, guessConnector)
     }

--- a/src/main/scala/com/tcooling/wordle/game/Wordle.scala
+++ b/src/main/scala/com/tcooling/wordle/game/Wordle.scala
@@ -5,7 +5,7 @@ import com.tcooling.wordle.game.WordleFSM.State
 import com.tcooling.wordle.input.GuessInputConnector
 import com.tcooling.wordle.model.FSM.{Exit, Start}
 import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
-import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig, WordsParserError}
+import com.tcooling.wordle.model.{FSM, TargetWord, WordGuess, WordleConfig, WordsParserError}
 import com.tcooling.wordle.parser.{FileReader, WordsParser}
 
 import scala.annotation.tailrec
@@ -23,13 +23,13 @@ final class Wordle(
       case Right(allWords) =>
         println(
           s"Successfully parsed ${config.filename}, read ${allWords.length} words of length ${config.wordLength.value}")
-        val targetWord = randomWord(allWords)
+        val targetWord = TargetWord.apply(randomWord(allWords))
         gameLoop(config, targetWord, allWords, guessConnector)
     }
 
   private def gameLoop(
       config: WordleConfig,
-      targetWord: String,
+      targetWord: TargetWord,
       allWords: NonEmptySet[String],
       guessConnector: GuessInputConnector
   ): Unit = {

--- a/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
+++ b/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
@@ -6,7 +6,7 @@ import com.tcooling.wordle.input.GuessInputConnector
 import com.tcooling.wordle.model.FSM.*
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.model.WordGuess.showWordGuess
-import com.tcooling.wordle.model.{boardRow, FSM, WordGuess, WordleConfig}
+import com.tcooling.wordle.model.{boardRow, FSM, NumberOfGuesses, WordGuess, WordLength, WordleConfig}
 import com.tcooling.wordle.parser.UserInputParser
 
 object WordleFSM {
@@ -51,15 +51,15 @@ object WordleFSM {
     Exit -> guesses
   }
 
-  private def checkForWinOrLoss(targetWord: String, numberOfGuesses: Int, guesses: List[WordGuess]): State =
+  private def checkForWinOrLoss(targetWord: String, numberOfGuesses: NumberOfGuesses, guesses: List[WordGuess]): State =
     if (guesses.lastOption.map(_.show).contains(targetWord)) Win -> guesses
-    else if (guesses.length == numberOfGuesses) Lose -> guesses
-    else UserInputGuess                              -> guesses
+    else if (guesses.length == numberOfGuesses.value) Lose -> guesses
+    else UserInputGuess                                    -> guesses
 
   private def userInputGuess(
       allWords: NonEmptySet[String],
       guessConnector: GuessInputConnector,
-      wordLength: Int,
+      wordLength: WordLength,
       targetWord: String,
       guesses: List[WordGuess]
   ): State = {

--- a/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
+++ b/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
@@ -6,7 +6,7 @@ import com.tcooling.wordle.input.GuessInputConnector
 import com.tcooling.wordle.model.FSM.*
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.model.WordGuess.showWordGuess
-import com.tcooling.wordle.model.{boardRow, FSM, NumberOfGuesses, WordGuess, WordLength, WordleConfig}
+import com.tcooling.wordle.model.{boardRow, FSM, NumberOfGuesses, TargetWord, WordGuess, WordLength, WordleConfig}
 import com.tcooling.wordle.parser.UserInputParser
 
 object WordleFSM {
@@ -21,7 +21,7 @@ object WordleFSM {
    */
   def nextState(
       config: WordleConfig,
-      targetWord: String,
+      targetWord: TargetWord,
       allWords: NonEmptySet[String],
       guessConnector: GuessInputConnector
   )(state: FSM, guesses: List[WordGuess]): State = state match {
@@ -46,13 +46,15 @@ object WordleFSM {
     Exit -> guesses
   }
 
-  private def lose(targetWord: String, guesses: List[WordGuess]): State = {
-    println(s"You failed to guess the word, the word was $targetWord")
+  private def lose(targetWord: TargetWord, guesses: List[WordGuess]): State = {
+    println(s"You failed to guess the word, the word was ${targetWord.value}")
     Exit -> guesses
   }
 
-  private def checkForWinOrLoss(targetWord: String, numberOfGuesses: NumberOfGuesses, guesses: List[WordGuess]): State =
-    if (guesses.lastOption.map(_.show).contains(targetWord)) Win -> guesses
+  private def checkForWinOrLoss(targetWord: TargetWord,
+                                numberOfGuesses: NumberOfGuesses,
+                                guesses: List[WordGuess]): State =
+    if (guesses.lastOption.map(_.show).contains(targetWord.value)) Win -> guesses
     else if (guesses.length == numberOfGuesses.value) Lose -> guesses
     else UserInputGuess                                    -> guesses
 
@@ -60,7 +62,7 @@ object WordleFSM {
       allWords: NonEmptySet[String],
       guessConnector: GuessInputConnector,
       wordLength: WordLength,
-      targetWord: String,
+      targetWord: TargetWord,
       guesses: List[WordGuess]
   ): State = {
     println("Guess: ")

--- a/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
+++ b/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
@@ -109,7 +109,7 @@ object WordleFSM {
       )
     )
     println("The letter I is in the word but in the wrong spot.")
-    println(GameBoard.generateBoardRow(WordGuess("VAGUE".map(IncorrectGuess).toList)))
+    println(GameBoard.generateBoardRow(WordGuess("VAGUE".map(IncorrectGuess.apply).toList)))
     println("None of the letters are in the word in any spot.")
     println(separator)
     PrintGameBoard -> Nil

--- a/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
+++ b/src/main/scala/com/tcooling/wordle/game/WordleFSM.scala
@@ -3,10 +3,10 @@ package com.tcooling.wordle.game
 import cats.data.NonEmptySet
 import cats.implicits.toShow
 import com.tcooling.wordle.input.GuessInputConnector
-import com.tcooling.wordle.model.FSM._
+import com.tcooling.wordle.model.FSM.*
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.model.WordGuess.showWordGuess
-import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
+import com.tcooling.wordle.model.{boardRow, FSM, WordGuess, WordleConfig}
 import com.tcooling.wordle.parser.UserInputParser
 
 object WordleFSM {
@@ -20,11 +20,11 @@ object WordleFSM {
    * Given a current FSM state and a list of guesses, a new FSM state and updated list of guesses will be returned
    */
   def nextState(
-    config:         WordleConfig,
-    targetWord:     String,
-    allWords:       NonEmptySet[String],
-    guessConnector: GuessInputConnector
-  )(state:          FSM, guesses: List[WordGuess]): State = state match {
+      config: WordleConfig,
+      targetWord: String,
+      allWords: NonEmptySet[String],
+      guessConnector: GuessInputConnector
+  )(state: FSM, guesses: List[WordGuess]): State = state match {
     case Start             => PrintHelp -> Nil
     case PrintHelp         => printHelp(config)
     case PrintGameBoard    => printGameBoard(guesses, config)
@@ -57,14 +57,14 @@ object WordleFSM {
     else UserInputGuess                              -> guesses
 
   private def userInputGuess(
-    allWords:       NonEmptySet[String],
-    guessConnector: GuessInputConnector,
-    wordLength:     Int,
-    targetWord:     String,
-    guesses:        List[WordGuess]
+      allWords: NonEmptySet[String],
+      guessConnector: GuessInputConnector,
+      wordLength: Int,
+      targetWord: String,
+      guesses: List[WordGuess]
   ): State = {
     println("Guess: ")
-    val guess = guessConnector.getUserInput()
+    val guess = guessConnector.getUserInput
     val updatedGuesses = UserInputParser.parseGuess(allWords, guess, wordLength) match {
       case Left(err) =>
         println(err.show + "\nPlease try again.")
@@ -82,34 +82,30 @@ object WordleFSM {
     println("After each guess, the color of the tiles will change to show how close your guess was to the word.")
     println("Examples")
     println(
-      GameBoard.generateBoardRow(
-        WordGuess(
-          List(
-            CorrectGuess('W'),
-            IncorrectGuess('E'),
-            IncorrectGuess('A'),
-            IncorrectGuess('R'),
-            IncorrectGuess('Y')
-          )
+      WordGuess(
+        List(
+          CorrectGuess('W'),
+          IncorrectGuess('E'),
+          IncorrectGuess('A'),
+          IncorrectGuess('R'),
+          IncorrectGuess('Y')
         )
-      )
+      ).boardRow
     )
     println("The letter W is in the word and in the correct spot.")
     println(
-      GameBoard.generateBoardRow(
-        WordGuess(
-          List(
-            IncorrectGuess('P'),
-            WrongPositionGuess('I'),
-            IncorrectGuess('L'),
-            IncorrectGuess('L'),
-            IncorrectGuess('S')
-          )
+      WordGuess(
+        List(
+          IncorrectGuess('P'),
+          WrongPositionGuess('I'),
+          IncorrectGuess('L'),
+          IncorrectGuess('L'),
+          IncorrectGuess('S')
         )
-      )
+      ).boardRow
     )
     println("The letter I is in the word but in the wrong spot.")
-    println(GameBoard.generateBoardRow(WordGuess("VAGUE".map(IncorrectGuess.apply).toList)))
+    println(WordGuess("VAGUE".map(IncorrectGuess.apply).toList).boardRow)
     println("None of the letters are in the word in any spot.")
     println(separator)
     PrintGameBoard -> Nil

--- a/src/main/scala/com/tcooling/wordle/input/ComputerInputGuessConnector.scala
+++ b/src/main/scala/com/tcooling/wordle/input/ComputerInputGuessConnector.scala
@@ -5,6 +5,6 @@ final class ComputerInputGuessConnector() extends GuessInputConnector {
   /**
    * When implementing, will need to pass the word set and config to this class
    */
-  override def getUserInput(): String = "TODO"
+  override def getUserInput: String = "TODO"
 
 }

--- a/src/main/scala/com/tcooling/wordle/input/ComputerInputGuessConnector.scala
+++ b/src/main/scala/com/tcooling/wordle/input/ComputerInputGuessConnector.scala
@@ -1,10 +1,10 @@
 package com.tcooling.wordle.input
 
-import cats.data.NonEmptySet
-import com.tcooling.wordle.model.WordleConfig
+final class ComputerInputGuessConnector() extends GuessInputConnector {
 
-final class ComputerInputGuessConnector(wordSet: NonEmptySet[String], wordleConfig: WordleConfig) extends GuessInputConnector {
-
+  /**
+   * When implementing, will need to pass the word set and config to this class
+   */
   override def getUserInput(): String = "TODO"
 
 }

--- a/src/main/scala/com/tcooling/wordle/input/GuessInputConnector.scala
+++ b/src/main/scala/com/tcooling/wordle/input/GuessInputConnector.scala
@@ -4,8 +4,9 @@ trait GuessInputConnector {
 
   /**
    * Get the guess from the user
-   * @return the user input guess
+   * @return
+   *   the user input guess
    */
-  def getUserInput(): String
+  def getUserInput: String
 
 }

--- a/src/main/scala/com/tcooling/wordle/input/UserInputGuessConnector.scala
+++ b/src/main/scala/com/tcooling/wordle/input/UserInputGuessConnector.scala
@@ -1,5 +1,5 @@
 package com.tcooling.wordle.input
 
 object UserInputGuessConnector extends GuessInputConnector {
-  override def getUserInput(): String = scala.io.StdIn.readLine()
+  override def getUserInput: String = scala.io.StdIn.readLine()
 }

--- a/src/main/scala/com/tcooling/wordle/model/FSM.scala
+++ b/src/main/scala/com/tcooling/wordle/model/FSM.scala
@@ -1,18 +1,9 @@
 package com.tcooling.wordle.model
 
 /**
- * This ADT represents every possible state in a Wordle game. The first state will always be Start and the final
- * state will always be Exit.
+ * This enum represents every possible state in a Wordle game. The first state will always be Start and the final state
+ * will always be Exit.
  */
-sealed trait FSM
-
-object FSM {
-  case object Start extends FSM
-  case object PrintHelp extends FSM
-  case object PrintGameBoard extends FSM
-  case object CheckForWinOrLoss extends FSM
-  case object UserInputGuess extends FSM
-  case object Win extends FSM
-  case object Lose extends FSM
-  case object Exit extends FSM
+enum FSM {
+  case Start, PrintHelp, PrintGameBoard, CheckForWinOrLoss, UserInputGuess, Win, Lose, Exit
 }

--- a/src/main/scala/com/tcooling/wordle/model/FSM.scala
+++ b/src/main/scala/com/tcooling/wordle/model/FSM.scala
@@ -7,12 +7,12 @@ package com.tcooling.wordle.model
 sealed trait FSM
 
 object FSM {
-  final case object Start extends FSM
-  final case object PrintHelp extends FSM
-  final case object PrintGameBoard extends FSM
-  final case object CheckForWinOrLoss extends FSM
-  final case object UserInputGuess extends FSM
-  final case object Win extends FSM
-  final case object Lose extends FSM
-  final case object Exit extends FSM
+  case object Start extends FSM
+  case object PrintHelp extends FSM
+  case object PrintGameBoard extends FSM
+  case object CheckForWinOrLoss extends FSM
+  case object UserInputGuess extends FSM
+  case object Win extends FSM
+  case object Lose extends FSM
+  case object Exit extends FSM
 }

--- a/src/main/scala/com/tcooling/wordle/model/LetterGuess.scala
+++ b/src/main/scala/com/tcooling/wordle/model/LetterGuess.scala
@@ -7,7 +7,7 @@ import cats.Show
  * @param consoleColour
  *   the colour in which to print the guess letter when displaying the board
  */
-sealed abstract class LetterGuess(val consoleColour: String) {
+sealed trait LetterGuess(val consoleColour: String) {
   val letter: Char
 }
 

--- a/src/main/scala/com/tcooling/wordle/model/LetterGuess.scala
+++ b/src/main/scala/com/tcooling/wordle/model/LetterGuess.scala
@@ -4,7 +4,8 @@ import cats.Show
 
 /**
  * For a particular letter in the users guess, encapsulate the result of the guess
- * @param consoleColour the colour in which to print the guess letter when displaying the board
+ * @param consoleColour
+ *   the colour in which to print the guess letter when displaying the board
  */
 sealed abstract class LetterGuess(val consoleColour: String) {
   val letter: Char

--- a/src/main/scala/com/tcooling/wordle/model/TargetWord.scala
+++ b/src/main/scala/com/tcooling/wordle/model/TargetWord.scala
@@ -1,0 +1,8 @@
+package com.tcooling.wordle.model
+
+opaque type TargetWord = String
+
+object TargetWord {
+  def apply(value: String): TargetWord                 = value
+  extension (targetWord: TargetWord) def value: String = targetWord
+}

--- a/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
+++ b/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
@@ -11,6 +11,6 @@ object UserInputError {
   }
 
   final case class IncorrectLength(wordLength: Int) extends UserInputError(s"Guess length not equal to $wordLength")
-  case object NonLetterCharacter extends UserInputError("Guess contained non letter character")
-  case object WordDoesNotExist extends UserInputError("Guess word does not exist")
+  case object NonLetterCharacter                    extends UserInputError("Guess contained non letter character")
+  case object WordDoesNotExist                      extends UserInputError("Guess word does not exist")
 }

--- a/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
+++ b/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
@@ -2,7 +2,7 @@ package com.tcooling.wordle.model
 
 import cats.Show
 
-sealed abstract class UserInputError(val errorMessage: String)
+sealed trait UserInputError(val errorMessage: String)
 
 object UserInputError {
 

--- a/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
+++ b/src/main/scala/com/tcooling/wordle/model/UserInputError.scala
@@ -11,6 +11,6 @@ object UserInputError {
   }
 
   final case class IncorrectLength(wordLength: Int) extends UserInputError(s"Guess length not equal to $wordLength")
-  final case object NonLetterCharacter extends UserInputError("Guess contained non letter character")
-  final case object WordDoesNotExist extends UserInputError("Guess word does not exist")
+  case object NonLetterCharacter extends UserInputError("Guess contained non letter character")
+  case object WordDoesNotExist extends UserInputError("Guess word does not exist")
 }

--- a/src/main/scala/com/tcooling/wordle/model/WordGuess.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordGuess.scala
@@ -2,6 +2,7 @@ package com.tcooling.wordle.model
 
 import cats.Show
 import cats.implicits.toShow
+import com.tcooling.wordle.model.TargetWord
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.game.GameBoard.{endSeparator, startSeparator}
 
@@ -14,11 +15,11 @@ object WordGuess {
    * From the user input word guess, create the [[WordGuess]] model. At this stage we have validated the length of the
    * target word and length of the guess so they can be zipped up and compared.
    */
-  def apply(userInput: String, targetWord: String): WordGuess =
-    WordGuess(userInput.zip(targetWord).toList.map {
-      case (letterGuess, target) if letterGuess == target       => CorrectGuess(letterGuess)
-      case (letterGuess, _) if targetWord.contains(letterGuess) => WrongPositionGuess(letterGuess)
-      case (letterGuess, _)                                     => IncorrectGuess(letterGuess)
+  def apply(userInput: String, targetWord: TargetWord): WordGuess =
+    WordGuess(userInput.zip(targetWord.value).toList.map {
+      case (letterGuess, target) if letterGuess == target             => CorrectGuess(letterGuess)
+      case (letterGuess, _) if targetWord.value.contains(letterGuess) => WrongPositionGuess(letterGuess)
+      case (letterGuess, _)                                           => IncorrectGuess(letterGuess)
     })
 }
 

--- a/src/main/scala/com/tcooling/wordle/model/WordGuess.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordGuess.scala
@@ -1,7 +1,9 @@
 package com.tcooling.wordle.model
 
 import cats.Show
+import cats.implicits.toShow
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
+import com.tcooling.wordle.game.GameBoard.{endSeparator, startSeparator}
 
 final case class WordGuess(letterGuesses: List[LetterGuess])
 
@@ -9,8 +11,8 @@ object WordGuess {
   implicit val showWordGuess: Show[WordGuess] = Show.show(_.letterGuesses.map(_.letter).mkString)
 
   /**
-   * From the user input word guess, create the [[WordGuess]] model. At this stage we have validated the length
-   * of the target word and length of the guess so they can be zipped up and compared.
+   * From the user input word guess, create the [[WordGuess]] model. At this stage we have validated the length of the
+   * target word and length of the guess so they can be zipped up and compared.
    */
   def apply(userInput: String, targetWord: String): WordGuess =
     WordGuess(userInput.zip(targetWord).toList.map {
@@ -18,4 +20,15 @@ object WordGuess {
       case (letterGuess, _) if targetWord.contains(letterGuess) => WrongPositionGuess(letterGuess)
       case (letterGuess, _)                                     => IncorrectGuess(letterGuess)
     })
+}
+
+extension (wordGuess: WordGuess) {
+
+  /**
+   * Given the [[WordGuess]], create the string to be printed. The only character that is displayed using a console
+   * colour is the letter guess itself, which is between a start and end separator.
+   */
+  def boardRow: String = wordGuess.letterGuesses.map { letterGuess =>
+    s"$startSeparator${letterGuess.show}$endSeparator"
+  }.mkString
 }

--- a/src/main/scala/com/tcooling/wordle/model/WordleConfig.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordleConfig.scala
@@ -1,7 +1,28 @@
 package com.tcooling.wordle.model
 
 final case class WordleConfig(
-    filename: String,
-    wordLength: Int,
-    numberOfGuesses: Int
+    filename: Filename,
+    wordLength: WordLength,
+    numberOfGuesses: NumberOfGuesses
 )
+
+opaque type Filename = String
+
+object Filename {
+  def apply(value: String): Filename               = value
+  extension (filename: Filename) def value: String = filename
+}
+
+opaque type WordLength = Int
+
+object WordLength {
+  def apply(value: Int): WordLength                 = value
+  extension (wordLength: WordLength) def value: Int = wordLength
+}
+
+opaque type NumberOfGuesses = Int
+
+object NumberOfGuesses {
+  def apply(value: Int): NumberOfGuesses                      = value
+  extension (numberOfGuesses: NumberOfGuesses) def value: Int = numberOfGuesses
+}

--- a/src/main/scala/com/tcooling/wordle/model/WordleConfig.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordleConfig.scala
@@ -1,7 +1,7 @@
 package com.tcooling.wordle.model
 
 final case class WordleConfig(
-  filename:        String,
-  wordLength:      Int,
-  numberOfGuesses: Int
+    filename: String,
+    wordLength: Int,
+    numberOfGuesses: Int
 )

--- a/src/main/scala/com/tcooling/wordle/model/WordsParserError.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordsParserError.scala
@@ -3,10 +3,6 @@ package com.tcooling.wordle.model
 /**
  * Possible errors from parsing the words file
  */
-sealed trait WordsParserError
-
-object WordsParserError {
-  case object FileParseError extends WordsParserError
-  case object EmptyFileError extends WordsParserError
-  case object InvalidWordsError extends WordsParserError
+enum WordsParserError {
+  case FileParseError, EmptyFileError, InvalidWordsError
 }

--- a/src/main/scala/com/tcooling/wordle/model/WordsParserError.scala
+++ b/src/main/scala/com/tcooling/wordle/model/WordsParserError.scala
@@ -6,7 +6,7 @@ package com.tcooling.wordle.model
 sealed trait WordsParserError
 
 object WordsParserError {
-  final case object FileParseError extends WordsParserError
-  final case object EmptyFileError extends WordsParserError
-  final case object InvalidWordsError extends WordsParserError
+  case object FileParseError extends WordsParserError
+  case object EmptyFileError extends WordsParserError
+  case object InvalidWordsError extends WordsParserError
 }

--- a/src/main/scala/com/tcooling/wordle/parser/FileReader.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/FileReader.scala
@@ -1,10 +1,11 @@
 package com.tcooling.wordle.parser
 
+import com.tcooling.wordle.model.Filename
 import scala.util.Try
 
 /**
  * Implement for a particular type of file, e.g. words .txt file
  */
 trait FileReader {
-  def getLines(filename: String): Try[List[String]]
+  def getLines(filename: Filename): Try[List[String]]
 }

--- a/src/main/scala/com/tcooling/wordle/parser/UserInputParser.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/UserInputParser.scala
@@ -9,14 +9,15 @@ object UserInputParser {
   /**
    * Validate that the user input is of the correct length, only contains valid characters and is a valid word.
    */
-  def parseGuess(allWords: NonEmptySet[String], userInput: String, wordLength: Int): Either[UserInputError, String] = for {
-    _ <- if (userInput.length == wordLength) Right(userInput) else Left(IncorrectLength(wordLength))
-    guess <- WordRegex.validate[Either[UserInputError, String]](
-               word = userInput,
-               ifMatchesRegex = Right(userInput.toUpperCase),
-               ifDoesNotMatchRegex = Left(NonLetterCharacter)
-             )
-    validGuess <- if (allWords.contains(guess)) Right(guess) else Left(WordDoesNotExist)
-  } yield validGuess
+  def parseGuess(allWords: NonEmptySet[String], userInput: String, wordLength: Int): Either[UserInputError, String] =
+    for {
+      _ <- if (userInput.length == wordLength) Right(userInput) else Left(IncorrectLength(wordLength))
+      guess <- WordRegex.validate[Either[UserInputError, String]](
+        word = userInput,
+        ifMatchesRegex = Right(userInput.toUpperCase),
+        ifDoesNotMatchRegex = Left(NonLetterCharacter)
+      )
+      validGuess <- if (allWords.contains(guess)) Right(guess) else Left(WordDoesNotExist)
+    } yield validGuess
 
 }

--- a/src/main/scala/com/tcooling/wordle/parser/UserInputParser.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/UserInputParser.scala
@@ -1,7 +1,7 @@
 package com.tcooling.wordle.parser
 
 import cats.data.NonEmptySet
-import com.tcooling.wordle.model.UserInputError
+import com.tcooling.wordle.model.{UserInputError, WordLength}
 import com.tcooling.wordle.model.UserInputError.{IncorrectLength, NonLetterCharacter, WordDoesNotExist}
 
 object UserInputParser {
@@ -9,9 +9,11 @@ object UserInputParser {
   /**
    * Validate that the user input is of the correct length, only contains valid characters and is a valid word.
    */
-  def parseGuess(allWords: NonEmptySet[String], userInput: String, wordLength: Int): Either[UserInputError, String] =
+  def parseGuess(allWords: NonEmptySet[String],
+                 userInput: String,
+                 wordLength: WordLength): Either[UserInputError, String] =
     for {
-      _ <- if (userInput.length == wordLength) Right(userInput) else Left(IncorrectLength(wordLength))
+      _ <- if (userInput.length == wordLength.value) Right(userInput) else Left(IncorrectLength(wordLength.value))
       guess <- WordRegex.validate[Either[UserInputError, String]](
         word = userInput,
         ifMatchesRegex = Right(userInput.toUpperCase),

--- a/src/main/scala/com/tcooling/wordle/parser/WordsParser.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/WordsParser.scala
@@ -1,10 +1,10 @@
 package com.tcooling.wordle.parser
 
 import cats.data.{NonEmptyList, NonEmptySet}
-import com.tcooling.wordle.model.WordsParserError
+import com.tcooling.wordle.model.{Filename, WordLength, WordsParserError}
 import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
 
-final class WordsParser(filename: String, wordLength: Int, fileReader: FileReader) {
+final class WordsParser(filename: Filename, wordLength: WordLength, fileReader: FileReader) {
 
   def parseWords: Either[WordsParserError, NonEmptySet[String]] = for {
     words                    <- fileReader.getLines(filename).toOption.toRight(FileParseError)
@@ -14,7 +14,7 @@ final class WordsParser(filename: String, wordLength: Int, fileReader: FileReade
   } yield wordsWithoutSpecialChars.map(_.toUpperCase)
 
   private def filterIncorrectLength(words: NonEmptySet[String]): Either[WordsParserError, NonEmptySet[String]] =
-    NonEmptySet.fromSet(words.filter(_.length == wordLength)).toRight(InvalidWordsError)
+    NonEmptySet.fromSet(words.filter(_.length == wordLength.value)).toRight(InvalidWordsError)
 
   private def filterNonLetterChars(words: NonEmptySet[String]): Either[WordsParserError, NonEmptySet[String]] =
     NonEmptySet

--- a/src/main/scala/com/tcooling/wordle/parser/WordsParser.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/WordsParser.scala
@@ -4,12 +4,7 @@ import cats.data.{NonEmptyList, NonEmptySet}
 import com.tcooling.wordle.model.WordsParserError
 import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
 
-object WordsParser {
-  def apply(filename: String, wordLength: Int, fileReader: FileReader): WordsParser =
-    new WordsParser(filename, wordLength, fileReader)
-}
-
-final class WordsParser private (filename: String, wordLength: Int, fileReader: FileReader) {
+final class WordsParser(filename: String, wordLength: Int, fileReader: FileReader) {
 
   def parseWords: Either[WordsParserError, NonEmptySet[String]] = for {
     words                    <- fileReader.getLines(filename).toOption.toRight(FileParseError)

--- a/src/main/scala/com/tcooling/wordle/parser/WordsReader.scala
+++ b/src/main/scala/com/tcooling/wordle/parser/WordsReader.scala
@@ -1,13 +1,14 @@
 package com.tcooling.wordle.parser
 
+import com.tcooling.wordle.model.Filename
 import scala.io.Source
 import scala.util.Try
 
 object WordsReader extends FileReader {
 
-  override def getLines(filename: String): Try[List[String]] =
+  override def getLines(filename: Filename): Try[List[String]] =
     Try {
-      val bufferedSource = Source.fromResource(filename)
+      val bufferedSource = Source.fromResource(filename.value)
       val lines          = bufferedSource.getLines().toList
       bufferedSource.close()
       lines

--- a/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
@@ -1,16 +1,16 @@
 package com.tcooling.wordle.game
 
-import com.tcooling.wordle.model.{boardRow, WordGuess}
+import com.tcooling.wordle.model.{boardRow, NumberOfGuesses, WordGuess, WordLength}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
 final class GameBoardTest extends AnyWordSpecLike with Matchers {
 
-  private val startSeparator: Char = '['
-  private val endSeparator: Char   = ']'
-  private val wordLength: Int      = 5
-  private val numGuesses: Int      = 6
-  private val targetWord: String   = "VAGUE"
+  private val startSeparator: Char        = '['
+  private val endSeparator: Char          = ']'
+  private val wordLength: WordLength      = WordLength.apply(5)
+  private val numGuesses: NumberOfGuesses = NumberOfGuesses.apply(6)
+  private val targetWord: String          = "VAGUE"
 
   private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
   private val generateGameBoardF: List[WordGuess] => List[String] =
@@ -43,10 +43,10 @@ final class GameBoardTest extends AnyWordSpecLike with Matchers {
     }
 
     "generate the whole game board" when {
-      val emptyRow = List.fill(wordLength)(s"$startSeparator $endSeparator").mkString
+      val emptyRow = List.fill(wordLength.value)(s"$startSeparator $endSeparator").mkString
 
       "no guesses have been input" in {
-        generateGameBoardF(Nil) shouldBe List.fill(numGuesses)(emptyRow)
+        generateGameBoardF(Nil) shouldBe List.fill(numGuesses.value)(emptyRow)
       }
 
       "one guess has been input" in {

--- a/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
@@ -1,37 +1,38 @@
 package com.tcooling.wordle.game
 
-import com.tcooling.wordle.model.WordGuess
+import com.tcooling.wordle.model.{boardRow, WordGuess}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
 final class GameBoardTest extends AnyWordSpecLike with Matchers {
 
-  private val startSeparator: Char   = '['
-  private val endSeparator:   Char   = ']'
-  private val wordLength:     Int    = 5
-  private val numGuesses:     Int    = 6
-  private val targetWord:     String = "VAGUE"
+  private val startSeparator: Char = '['
+  private val endSeparator: Char   = ']'
+  private val wordLength: Int      = 5
+  private val numGuesses: Int      = 6
+  private val targetWord: String   = "VAGUE"
 
-  private val wordGuessF:         String => WordGuess             = WordGuess(_, targetWord)
-  private val generateGameBoardF: List[WordGuess] => List[String] = GameBoard.generateGameBoard(wordLength, numGuesses, _)
+  private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
+  private val generateGameBoardF: List[WordGuess] => List[String] =
+    GameBoard.generateGameBoard(wordLength, numGuesses, _)
 
   "GameBoard" should {
     "generate a board row" when {
       "none of the letters of the guess are in the target word" in {
-        GameBoard.generateBoardRow(wordGuessF("QQQQQ")) shouldBe createRow(Console.RED, "QQQQQ")
+        wordGuessF("QQQQQ").boardRow shouldBe createRow(Console.RED, "QQQQQ")
       }
 
       "all of the letters of the guess are in the target word in the correct position" in {
-        GameBoard.generateBoardRow(wordGuessF(targetWord)) shouldBe createRow(Console.GREEN, targetWord)
+        wordGuessF(targetWord).boardRow shouldBe createRow(Console.GREEN, targetWord)
       }
 
       "all of the letters of the guess are in the target word in the wrong position" in {
         val incorrectPositionWord = "AVUGA"
-        GameBoard.generateBoardRow(wordGuessF(incorrectPositionWord)) shouldBe createRow(Console.YELLOW, incorrectPositionWord)
+        wordGuessF(incorrectPositionWord).boardRow shouldBe createRow(Console.YELLOW, incorrectPositionWord)
       }
 
       "there are a mix of letters that are valid, in the incorrect position and invalid" in {
-        GameBoard.generateBoardRow(wordGuessF("HAVEN")) shouldBe List(
+        wordGuessF("HAVEN").boardRow shouldBe List(
           createSquare(Console.RED, 'H'),
           createSquare(Console.GREEN, 'A'),
           createSquare(Console.YELLOW, 'V'),

--- a/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
@@ -1,9 +1,10 @@
 package com.tcooling.wordle.game
 
 import com.tcooling.wordle.model.WordGuess
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class GameBoardTest extends WordSpecLike with Matchers {
+final class GameBoardTest extends AnyWordSpecLike with Matchers {
 
   private val startSeparator: Char   = '['
   private val endSeparator:   Char   = ']'
@@ -41,7 +42,7 @@ final class GameBoardTest extends WordSpecLike with Matchers {
     }
 
     "generate the whole game board" when {
-      val emptyRow = List.fill(wordLength)(startSeparator + " " + endSeparator).mkString
+      val emptyRow = List.fill(wordLength)(s"$startSeparator $endSeparator").mkString
 
       "no guesses have been input" in {
         generateGameBoardF(Nil) shouldBe List.fill(numGuesses)(emptyRow)
@@ -76,6 +77,6 @@ final class GameBoardTest extends WordSpecLike with Matchers {
     word.map(createSquare(consoleColour, _)).mkString
 
   private def createSquare(consoleColour: String, letter: Char): String =
-    startSeparator + consoleColour + letter + Console.RESET + endSeparator
+    s"$startSeparator$consoleColour$letter${Console.RESET}$endSeparator"
 
 }

--- a/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/GameBoardTest.scala
@@ -1,6 +1,6 @@
 package com.tcooling.wordle.game
 
-import com.tcooling.wordle.model.{boardRow, NumberOfGuesses, WordGuess, WordLength}
+import com.tcooling.wordle.model.{boardRow, NumberOfGuesses, TargetWord, WordGuess, WordLength}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -10,7 +10,7 @@ final class GameBoardTest extends AnyWordSpecLike with Matchers {
   private val endSeparator: Char          = ']'
   private val wordLength: WordLength      = WordLength.apply(5)
   private val numGuesses: NumberOfGuesses = NumberOfGuesses.apply(6)
-  private val targetWord: String          = "VAGUE"
+  private val targetWord: TargetWord      = TargetWord.apply("VAGUE")
 
   private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
   private val generateGameBoardF: List[WordGuess] => List[String] =
@@ -23,7 +23,7 @@ final class GameBoardTest extends AnyWordSpecLike with Matchers {
       }
 
       "all of the letters of the guess are in the target word in the correct position" in {
-        wordGuessF(targetWord).boardRow shouldBe createRow(Console.GREEN, targetWord)
+        wordGuessF(targetWord.value).boardRow shouldBe createRow(Console.GREEN, targetWord.value)
       }
 
       "all of the letters of the guess are in the target word in the wrong position" in {
@@ -50,8 +50,8 @@ final class GameBoardTest extends AnyWordSpecLike with Matchers {
       }
 
       "one guess has been input" in {
-        generateGameBoardF(List(WordGuess(targetWord, targetWord))) shouldBe List(
-          createRow(Console.GREEN, targetWord),
+        generateGameBoardF(List(WordGuess(targetWord.value, targetWord))) shouldBe List(
+          createRow(Console.GREEN, targetWord.value),
           emptyRow,
           emptyRow,
           emptyRow,
@@ -61,14 +61,14 @@ final class GameBoardTest extends AnyWordSpecLike with Matchers {
       }
 
       "all the guesses have been input" in {
-        val words = List("UEAVG", "XXXXX", "QQQQQ", "WWWWW", "ZZZZZ", targetWord)
+        val words = List("UEAVG", "XXXXX", "QQQQQ", "WWWWW", "ZZZZZ", targetWord.value)
         generateGameBoardF(words.map(WordGuess(_, targetWord))) shouldBe List(
           createRow(Console.YELLOW, "UEAVG"),
           createRow(Console.RED, "XXXXX"),
           createRow(Console.RED, "QQQQQ"),
           createRow(Console.RED, "WWWWW"),
           createRow(Console.RED, "ZZZZZ"),
-          createRow(Console.GREEN, targetWord)
+          createRow(Console.GREEN, targetWord.value)
         )
       }
     }

--- a/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
@@ -16,15 +16,16 @@ final class WordleFSMTest extends AnyWordSpecLike with Matchers {
     numberOfGuesses = 6
   )
 
-  private val word1:       String              = "HELLO"
-  private val word2:       String              = "CLICK"
-  private val word3:       String              = "HORSE"
-  private val word4:       String              = "GREAT"
-  private val word5:       String              = "ELDER"
-  private val word6:       String              = "CLEAN"
-  private val targetWord:  String              = "VAGUE"
-  private val missingWord: String              = "ABCDE"
-  private val allWords:    NonEmptySet[String] = NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
+  private val word1: String       = "HELLO"
+  private val word2: String       = "CLICK"
+  private val word3: String       = "HORSE"
+  private val word4: String       = "GREAT"
+  private val word5: String       = "ELDER"
+  private val word6: String       = "CLEAN"
+  private val targetWord: String  = "VAGUE"
+  private val missingWord: String = "ABCDE"
+  private val allWords: NonEmptySet[String] =
+    NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
 
   private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
 
@@ -33,7 +34,9 @@ final class WordleFSMTest extends AnyWordSpecLike with Matchers {
       config = wordleConfig,
       targetWord = targetWord,
       allWords = allWords,
-      guessConnector = () => guess
+      guessConnector = new GuessInputConnector {
+        override def getUserInput: String = guess
+      }
     )(state, guesses)
 
   "WordleFSM" should {

--- a/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
@@ -2,7 +2,7 @@ package com.tcooling.wordle.game
 
 import cats.data.{NonEmptyList, NonEmptySet}
 import com.tcooling.wordle.input.GuessInputConnector
-import com.tcooling.wordle.model.WordLength
+import com.tcooling.wordle.model.{TargetWord, WordLength}
 import com.tcooling.wordle.model.FSM.*
 import com.tcooling.wordle.model.{FSM, Filename, NumberOfGuesses, WordGuess, WordleConfig}
 import WordleFSM.State
@@ -17,16 +17,16 @@ final class WordleFSMTest extends AnyWordSpecLike with Matchers {
     numberOfGuesses = NumberOfGuesses.apply(6)
   )
 
-  private val word1: String       = "HELLO"
-  private val word2: String       = "CLICK"
-  private val word3: String       = "HORSE"
-  private val word4: String       = "GREAT"
-  private val word5: String       = "ELDER"
-  private val word6: String       = "CLEAN"
-  private val targetWord: String  = "VAGUE"
-  private val missingWord: String = "ABCDE"
+  private val word1: String          = "HELLO"
+  private val word2: String          = "CLICK"
+  private val word3: String          = "HORSE"
+  private val word4: String          = "GREAT"
+  private val word5: String          = "ELDER"
+  private val word6: String          = "CLEAN"
+  private val targetWord: TargetWord = TargetWord.apply("VAGUE")
+  private val missingWord: String    = "ABCDE"
   private val allWords: NonEmptySet[String] =
-    NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
+    NonEmptyList.of(targetWord.value, word1, word2, word3, word4, word5, word6).toNes
 
   private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
 
@@ -66,12 +66,12 @@ final class WordleFSMTest extends AnyWordSpecLike with Matchers {
           }
 
           "the first guess is correct" in {
-            val guesses: List[WordGuess] = List(targetWord).map(wordGuessF)
+            val guesses: List[WordGuess] = List(targetWord.value).map(wordGuessF)
             withNextState(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
           }
 
           "the last guess is correct" in {
-            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord).map(wordGuessF)
+            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord.value).map(wordGuessF)
             withNextState(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
           }
         }
@@ -125,7 +125,8 @@ final class WordleFSMTest extends AnyWordSpecLike with Matchers {
       }
 
       "Win" in {
-        withNextState(Win, List(targetWord).map(wordGuessF)) shouldBe (Exit, List(targetWord).map(wordGuessF))
+        withNextState(Win, List(targetWord.value).map(wordGuessF)) shouldBe (Exit, List(targetWord.value).map(
+          wordGuessF))
       }
 
       "Lose" in {

--- a/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
@@ -1,140 +1,141 @@
-package com.tcooling.wordle.game
-
-import cats.data.{NonEmptyList, NonEmptySet}
-import com.tcooling.wordle.input.GuessInputConnector
-import com.tcooling.wordle.model.FSM._
-import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpecLike}
-
-final class WordleFSMTest extends WordSpecLike with Matchers with MockFactory {
-
-  private val wordleConfig: WordleConfig = WordleConfig(
-    filename = "words.txt",
-    wordLength = 5,
-    numberOfGuesses = 6
-  )
-
-  private val word1:          String              = "HELLO"
-  private val word2:          String              = "CLICK"
-  private val word3:          String              = "HORSE"
-  private val word4:          String              = "GREAT"
-  private val word5:          String              = "ELDER"
-  private val word6:          String              = "CLEAN"
-  private val targetWord:     String              = "VAGUE"
-  private val missingWord:    String              = "ABCDE"
-  private val allWords:       NonEmptySet[String] = NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
-  private val guessConnector: GuessInputConnector = mock[GuessInputConnector]
-
-  private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
-  private val nextStateF: (FSM, List[WordGuess]) => (FSM, List[WordGuess]) = WordleFSM.nextState(
-    config = wordleConfig,
-    targetWord = targetWord,
-    allWords = allWords,
-    guessConnector = guessConnector
-  )(_, _)
-
-  "WordleFSM" should {
-    "return the next state and guesses for a state" when {
-      "Start" in {
-        nextStateF(Start, Nil) shouldBe (PrintHelp, Nil)
-      }
-
-      "PrintHelp" in {
-        nextStateF(PrintHelp, Nil) shouldBe (PrintGameBoard, Nil)
-      }
-
-      "PrintGameBoard" in {
-        nextStateF(PrintGameBoard, Nil) shouldBe (CheckForWinOrLoss, Nil)
-      }
-
-      "CheckForWinOrLoss" when {
-        "no guesses are present" in {
-          nextStateF(CheckForWinOrLoss, Nil) shouldBe (UserInputGuess, Nil)
-        }
-
-        "guesses are present" when {
-          "all the guesses have been used" in {
-            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, word6).map(wordGuessF)
-            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Lose, guesses)
-          }
-
-          "the first guess is correct" in {
-            val guesses: List[WordGuess] = List(targetWord).map(wordGuessF)
-            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
-          }
-
-          "the last guess is correct" in {
-            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord).map(wordGuessF)
-            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
-          }
-        }
-      }
-
-      "UserInputGuess" when {
-        "a valid guess is input" when {
-          "the guess is in lowercase" in {
-            (guessConnector.getUserInput _).expects().returns(word1.toLowerCase)
-            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
-          }
-
-          "the guess is in uppercase" in {
-            (guessConnector.getUserInput _).expects().returns(word1)
-            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
-          }
-
-          "when the guess has already been input previously" in {
-            (guessConnector.getUserInput _).expects().returns(word1)
-            nextStateF(UserInputGuess, List(word1).map(wordGuessF)) shouldBe
-              (PrintGameBoard, List(word1, word1).map(wordGuessF))
-          }
-        }
-
-        "an invalid guess is input" when {
-          "the guess is the wrong length" when {
-            "empty" in {
-              (guessConnector.getUserInput _).expects().returns("")
-              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-            }
-
-            "too short" in {
-              (guessConnector.getUserInput _).expects().returns(word1.tail)
-              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-            }
-
-            "too long" in {
-              (guessConnector.getUserInput _).expects().returns(word1 + "Q")
-              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-            }
-          }
-
-          "the guess does not match the regex" when {
-            "includes special characters" in {
-              (guessConnector.getUserInput _).expects().returns("&&&&&")
-              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-            }
-
-            "includes numbers" in {
-              (guessConnector.getUserInput _).expects().returns("12345")
-              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-            }
-          }
-
-          "the guess does not correspond to a word in the words file" in {
-            (guessConnector.getUserInput _).expects().returns(missingWord)
-            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-          }
-        }
-      }
-
-      "Win" in {
-        nextStateF(Win, List(targetWord).map(wordGuessF)) shouldBe (Exit, List(targetWord).map(wordGuessF))
-      }
-
-      "Lose" in {
-        nextStateF(Lose, List(word1).map(wordGuessF)) shouldBe (Exit, List(word1).map(wordGuessF))
-      }
-    }
-  }
-
-}
+//package com.tcooling.wordle.game
+//
+//import cats.data.{NonEmptyList, NonEmptySet}
+//import com.tcooling.wordle.input.GuessInputConnector
+//import com.tcooling.wordle.model.FSM.*
+//import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
+//import org.scalamock.scalatest.MockFactory
+//import org.scalatest.wordspec.AnyWordSpecLike
+//import org.scalatest.Matchers
+//
+//final class WordleFSMTest extends AnyWordSpecLike with Matchers with MockFactory {
+//
+//  private val wordleConfig: WordleConfig = WordleConfig(
+//    filename = "words.txt",
+//    wordLength = 5,
+//    numberOfGuesses = 6
+//  )
+//
+//  private val word1:          String              = "HELLO"
+//  private val word2:          String              = "CLICK"
+//  private val word3:          String              = "HORSE"
+//  private val word4:          String              = "GREAT"
+//  private val word5:          String              = "ELDER"
+//  private val word6:          String              = "CLEAN"
+//  private val targetWord:     String              = "VAGUE"
+//  private val missingWord:    String              = "ABCDE"
+//  private val allWords:       NonEmptySet[String] = NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
+//  private val guessConnector: GuessInputConnector = mock[GuessInputConnector]
+//
+//  private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
+//  private val nextStateF: (FSM, List[WordGuess]) => (FSM, List[WordGuess]) = WordleFSM.nextState(
+//    config = wordleConfig,
+//    targetWord = targetWord,
+//    allWords = allWords,
+//    guessConnector = guessConnector
+//  )(_, _)
+//
+//  "WordleFSM" should {
+//    "return the next state and guesses for a state" when {
+//      "Start" in {
+//        nextStateF(Start, Nil) shouldBe (PrintHelp, Nil)
+//      }
+//
+//      "PrintHelp" in {
+//        nextStateF(PrintHelp, Nil) shouldBe (PrintGameBoard, Nil)
+//      }
+//
+//      "PrintGameBoard" in {
+//        nextStateF(PrintGameBoard, Nil) shouldBe (CheckForWinOrLoss, Nil)
+//      }
+//
+//      "CheckForWinOrLoss" when {
+//        "no guesses are present" in {
+//          nextStateF(CheckForWinOrLoss, Nil) shouldBe (UserInputGuess, Nil)
+//        }
+//
+//        "guesses are present" when {
+//          "all the guesses have been used" in {
+//            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, word6).map(wordGuessF)
+//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Lose, guesses)
+//          }
+//
+//          "the first guess is correct" in {
+//            val guesses: List[WordGuess] = List(targetWord).map(wordGuessF)
+//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
+//          }
+//
+//          "the last guess is correct" in {
+//            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord).map(wordGuessF)
+//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
+//          }
+//        }
+//      }
+//
+//      "UserInputGuess" when {
+//        "a valid guess is input" when {
+//          "the guess is in lowercase" in {
+//            (guessConnector.getUserInput _).expects().returns(word1.toLowerCase)
+//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
+//          }
+//
+//          "the guess is in uppercase" in {
+//            (guessConnector.getUserInput _).expects().returns(word1)
+//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
+//          }
+//
+//          "when the guess has already been input previously" in {
+//            (guessConnector.getUserInput _).expects().returns(word1)
+//            nextStateF(UserInputGuess, List(word1).map(wordGuessF)) shouldBe
+//              (PrintGameBoard, List(word1, word1).map(wordGuessF))
+//          }
+//        }
+//
+//        "an invalid guess is input" when {
+//          "the guess is the wrong length" when {
+//            "empty" in {
+//              (guessConnector.getUserInput _).expects().returns("")
+//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//            }
+//
+//            "too short" in {
+//              (guessConnector.getUserInput _).expects().returns(word1.tail)
+//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//            }
+//
+//            "too long" in {
+//              (guessConnector.getUserInput _).expects().returns(word1 + "Q")
+//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//            }
+//          }
+//
+//          "the guess does not match the regex" when {
+//            "includes special characters" in {
+//              (guessConnector.getUserInput _).expects().returns("&&&&&")
+//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//            }
+//
+//            "includes numbers" in {
+//              (guessConnector.getUserInput _).expects().returns("12345")
+//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//            }
+//          }
+//
+//          "the guess does not correspond to a word in the words file" in {
+//            (guessConnector.getUserInput _).expects().returns(missingWord)
+//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
+//          }
+//        }
+//      }
+//
+//      "Win" in {
+//        nextStateF(Win, List(targetWord).map(wordGuessF)) shouldBe (Exit, List(targetWord).map(wordGuessF))
+//      }
+//
+//      "Lose" in {
+//        nextStateF(Lose, List(word1).map(wordGuessF)) shouldBe (Exit, List(word1).map(wordGuessF))
+//      }
+//    }
+//  }
+//
+//}

--- a/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
@@ -2,8 +2,9 @@ package com.tcooling.wordle.game
 
 import cats.data.{NonEmptyList, NonEmptySet}
 import com.tcooling.wordle.input.GuessInputConnector
+import com.tcooling.wordle.model.WordLength
 import com.tcooling.wordle.model.FSM.*
-import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
+import com.tcooling.wordle.model.{FSM, Filename, NumberOfGuesses, WordGuess, WordleConfig}
 import WordleFSM.State
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -11,9 +12,9 @@ import org.scalatest.matchers.should.Matchers
 final class WordleFSMTest extends AnyWordSpecLike with Matchers {
 
   private val wordleConfig: WordleConfig = WordleConfig(
-    filename = "words.txt",
-    wordLength = 5,
-    numberOfGuesses = 6
+    filename = Filename.apply("words.txt"),
+    wordLength = WordLength.apply(5),
+    numberOfGuesses = NumberOfGuesses.apply(6)
   )
 
   private val word1: String       = "HELLO"

--- a/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleFSMTest.scala
@@ -1,141 +1,132 @@
-//package com.tcooling.wordle.game
-//
-//import cats.data.{NonEmptyList, NonEmptySet}
-//import com.tcooling.wordle.input.GuessInputConnector
-//import com.tcooling.wordle.model.FSM.*
-//import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
-//import org.scalamock.scalatest.MockFactory
-//import org.scalatest.wordspec.AnyWordSpecLike
-//import org.scalatest.Matchers
-//
-//final class WordleFSMTest extends AnyWordSpecLike with Matchers with MockFactory {
-//
-//  private val wordleConfig: WordleConfig = WordleConfig(
-//    filename = "words.txt",
-//    wordLength = 5,
-//    numberOfGuesses = 6
-//  )
-//
-//  private val word1:          String              = "HELLO"
-//  private val word2:          String              = "CLICK"
-//  private val word3:          String              = "HORSE"
-//  private val word4:          String              = "GREAT"
-//  private val word5:          String              = "ELDER"
-//  private val word6:          String              = "CLEAN"
-//  private val targetWord:     String              = "VAGUE"
-//  private val missingWord:    String              = "ABCDE"
-//  private val allWords:       NonEmptySet[String] = NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
-//  private val guessConnector: GuessInputConnector = mock[GuessInputConnector]
-//
-//  private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
-//  private val nextStateF: (FSM, List[WordGuess]) => (FSM, List[WordGuess]) = WordleFSM.nextState(
-//    config = wordleConfig,
-//    targetWord = targetWord,
-//    allWords = allWords,
-//    guessConnector = guessConnector
-//  )(_, _)
-//
-//  "WordleFSM" should {
-//    "return the next state and guesses for a state" when {
-//      "Start" in {
-//        nextStateF(Start, Nil) shouldBe (PrintHelp, Nil)
-//      }
-//
-//      "PrintHelp" in {
-//        nextStateF(PrintHelp, Nil) shouldBe (PrintGameBoard, Nil)
-//      }
-//
-//      "PrintGameBoard" in {
-//        nextStateF(PrintGameBoard, Nil) shouldBe (CheckForWinOrLoss, Nil)
-//      }
-//
-//      "CheckForWinOrLoss" when {
-//        "no guesses are present" in {
-//          nextStateF(CheckForWinOrLoss, Nil) shouldBe (UserInputGuess, Nil)
-//        }
-//
-//        "guesses are present" when {
-//          "all the guesses have been used" in {
-//            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, word6).map(wordGuessF)
-//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Lose, guesses)
-//          }
-//
-//          "the first guess is correct" in {
-//            val guesses: List[WordGuess] = List(targetWord).map(wordGuessF)
-//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
-//          }
-//
-//          "the last guess is correct" in {
-//            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord).map(wordGuessF)
-//            nextStateF(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
-//          }
-//        }
-//      }
-//
-//      "UserInputGuess" when {
-//        "a valid guess is input" when {
-//          "the guess is in lowercase" in {
-//            (guessConnector.getUserInput _).expects().returns(word1.toLowerCase)
-//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
-//          }
-//
-//          "the guess is in uppercase" in {
-//            (guessConnector.getUserInput _).expects().returns(word1)
-//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
-//          }
-//
-//          "when the guess has already been input previously" in {
-//            (guessConnector.getUserInput _).expects().returns(word1)
-//            nextStateF(UserInputGuess, List(word1).map(wordGuessF)) shouldBe
-//              (PrintGameBoard, List(word1, word1).map(wordGuessF))
-//          }
-//        }
-//
-//        "an invalid guess is input" when {
-//          "the guess is the wrong length" when {
-//            "empty" in {
-//              (guessConnector.getUserInput _).expects().returns("")
-//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//            }
-//
-//            "too short" in {
-//              (guessConnector.getUserInput _).expects().returns(word1.tail)
-//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//            }
-//
-//            "too long" in {
-//              (guessConnector.getUserInput _).expects().returns(word1 + "Q")
-//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//            }
-//          }
-//
-//          "the guess does not match the regex" when {
-//            "includes special characters" in {
-//              (guessConnector.getUserInput _).expects().returns("&&&&&")
-//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//            }
-//
-//            "includes numbers" in {
-//              (guessConnector.getUserInput _).expects().returns("12345")
-//              nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//            }
-//          }
-//
-//          "the guess does not correspond to a word in the words file" in {
-//            (guessConnector.getUserInput _).expects().returns(missingWord)
-//            nextStateF(UserInputGuess, Nil) shouldBe (PrintGameBoard, Nil)
-//          }
-//        }
-//      }
-//
-//      "Win" in {
-//        nextStateF(Win, List(targetWord).map(wordGuessF)) shouldBe (Exit, List(targetWord).map(wordGuessF))
-//      }
-//
-//      "Lose" in {
-//        nextStateF(Lose, List(word1).map(wordGuessF)) shouldBe (Exit, List(word1).map(wordGuessF))
-//      }
-//    }
-//  }
-//
-//}
+package com.tcooling.wordle.game
+
+import cats.data.{NonEmptyList, NonEmptySet}
+import com.tcooling.wordle.input.GuessInputConnector
+import com.tcooling.wordle.model.FSM.*
+import com.tcooling.wordle.model.{FSM, WordGuess, WordleConfig}
+import WordleFSM.State
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
+
+final class WordleFSMTest extends AnyWordSpecLike with Matchers {
+
+  private val wordleConfig: WordleConfig = WordleConfig(
+    filename = "words.txt",
+    wordLength = 5,
+    numberOfGuesses = 6
+  )
+
+  private val word1:       String              = "HELLO"
+  private val word2:       String              = "CLICK"
+  private val word3:       String              = "HORSE"
+  private val word4:       String              = "GREAT"
+  private val word5:       String              = "ELDER"
+  private val word6:       String              = "CLEAN"
+  private val targetWord:  String              = "VAGUE"
+  private val missingWord: String              = "ABCDE"
+  private val allWords:    NonEmptySet[String] = NonEmptyList.of(targetWord, word1, word2, word3, word4, word5, word6).toNes
+
+  private val wordGuessF: String => WordGuess = WordGuess(_, targetWord)
+
+  private def withNextState(state: FSM, guesses: List[WordGuess], guess: String = ""): State =
+    WordleFSM.nextState(
+      config = wordleConfig,
+      targetWord = targetWord,
+      allWords = allWords,
+      guessConnector = () => guess
+    )(state, guesses)
+
+  "WordleFSM" should {
+    "return the next state and guesses for a state" when {
+      "Start" in {
+        withNextState(Start, Nil) shouldBe (PrintHelp, Nil)
+      }
+
+      "PrintHelp" in {
+        withNextState(PrintHelp, Nil) shouldBe (PrintGameBoard, Nil)
+      }
+
+      "PrintGameBoard" in {
+        withNextState(PrintGameBoard, Nil) shouldBe (CheckForWinOrLoss, Nil)
+      }
+
+      "CheckForWinOrLoss" when {
+        "no guesses are present" in {
+          withNextState(CheckForWinOrLoss, Nil) shouldBe (UserInputGuess, Nil)
+        }
+
+        "guesses are present" when {
+          "all the guesses have been used" in {
+            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, word6).map(wordGuessF)
+            withNextState(CheckForWinOrLoss, guesses) shouldBe (Lose, guesses)
+          }
+
+          "the first guess is correct" in {
+            val guesses: List[WordGuess] = List(targetWord).map(wordGuessF)
+            withNextState(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
+          }
+
+          "the last guess is correct" in {
+            val guesses: List[WordGuess] = List(word1, word2, word3, word4, word5, targetWord).map(wordGuessF)
+            withNextState(CheckForWinOrLoss, guesses) shouldBe (Win, guesses)
+          }
+        }
+      }
+
+      "UserInputGuess" when {
+        "a valid guess is input" when {
+          "the guess is in lowercase" in {
+            withNextState(UserInputGuess, Nil, word1.toLowerCase) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
+          }
+
+          "the guess is in uppercase" in {
+            withNextState(UserInputGuess, Nil, word1) shouldBe (PrintGameBoard, List(word1).map(wordGuessF))
+          }
+
+          "when the guess has already been input previously" in {
+            withNextState(UserInputGuess, List(word1).map(wordGuessF), word1) shouldBe
+              (PrintGameBoard, List(word1, word1).map(wordGuessF))
+          }
+        }
+
+        "an invalid guess is input" when {
+          "the guess is the wrong length" when {
+            "empty" in {
+              withNextState(UserInputGuess, Nil, guess = "") shouldBe (PrintGameBoard, Nil)
+            }
+
+            "too short" in {
+              withNextState(UserInputGuess, Nil, word1.tail) shouldBe (PrintGameBoard, Nil)
+            }
+
+            "too long" in {
+              withNextState(UserInputGuess, Nil, guess = s"${word1}A") shouldBe (PrintGameBoard, Nil)
+            }
+          }
+
+          "the guess does not match the regex" when {
+            "includes special characters" in {
+              withNextState(UserInputGuess, Nil, guess = "&&&&&") shouldBe (PrintGameBoard, Nil)
+            }
+
+            "includes numbers" in {
+              withNextState(UserInputGuess, Nil, guess = "12345") shouldBe (PrintGameBoard, Nil)
+            }
+          }
+
+          "the guess does not correspond to a word in the words file" in {
+            withNextState(UserInputGuess, Nil, missingWord) shouldBe (PrintGameBoard, Nil)
+          }
+        }
+      }
+
+      "Win" in {
+        withNextState(Win, List(targetWord).map(wordGuessF)) shouldBe (Exit, List(targetWord).map(wordGuessF))
+      }
+
+      "Lose" in {
+        withNextState(Lose, List(word1).map(wordGuessF)) shouldBe (Exit, List(word1).map(wordGuessF))
+      }
+    }
+  }
+}

--- a/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
@@ -1,66 +1,67 @@
-package com.tcooling.wordle.game
-
-import cats.data.NonEmptySet
-import com.tcooling.wordle.input.GuessInputConnector
-import com.tcooling.wordle.model.WordleConfig
-import com.tcooling.wordle.parser.{FileReader, WordsReader}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpecLike}
-
-final class WordleTest extends WordSpecLike with Matchers with MockFactory {
-
-  private val targetWord: String = "VAGUE"
-  private val config: WordleConfig = WordleConfig(
-    filename = "words.txt",
-    wordLength = 5,
-    numberOfGuesses = 6
-  )
-  private val fileReader:        FileReader                    = WordsReader
-  private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord
-  private val guessConnector:    GuessInputConnector           = mock[GuessInputConnector]
-
-  "Wordle" should {
-    "handle a player winning the game" when {
-      "in all possible numbers of guesses" in {
-        List(
-          List(targetWord),
-          List("CLEAN", targetWord),
-          List("ELDER", "CLEAN", targetWord),
-          List("HORSE", "ELDER", "CLEAN", targetWord),
-          List("GREEN", "HORSE", "ELDER", "CLEAN", targetWord),
-          List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", targetWord)
-        ).foreach { userInputGuesses =>
-          withClue(s"for guesses $userInputGuesses") {
-            val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-            mockUserInputGuesses(userInputGuesses)
-            wordle.startGame()
-          }
-        }
-      }
-    }
-
-    "handle a player losing the game" when {
-      "each guess is valid" in {
-        val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-        mockUserInputGuesses(List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN"))
-        wordle.startGame()
-      }
-
-      "some guesses are the wrong number of letters, include special characters or are not valid words" in {
-        val wordle                  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-        val specialCharacterGuesses = List("&&&&&", "+++++", "%%%%%")
-        val nonLetterGuesses        = List("12345", "ABC12")
-        val wrongLengthGuesses      = List("", "ABC", "TESTING")
-        val invalidWordGuesses      = List("AAAAA", "BBBBB", "CCCCC")
-        val validGuesses            = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
-        val invalidGuesses          = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
-        mockUserInputGuesses(invalidGuesses ::: validGuesses)
-        wordle.startGame()
-      }
-    }
-  }
-
-  private def mockUserInputGuesses(guesses: List[String]): Unit =
-    guesses.foreach((guessConnector.getUserInput _).expects().returns(_))
-
-}
+//package com.tcooling.wordle.game
+//
+//import cats.data.NonEmptySet
+//import com.tcooling.wordle.input.GuessInputConnector
+//import com.tcooling.wordle.model.WordleConfig
+//import com.tcooling.wordle.parser.{FileReader, WordsReader}
+//import org.scalamock.scalatest.MockFactory
+//import org.scalatest.wordspec.AnyWordSpecLike
+//import org.scalatest.Matchers
+//
+//final class WordleTest extends AnyWordSpecLike with Matchers with MockFactory {
+//
+//  private val targetWord: String = "VAGUE"
+//  private val config: WordleConfig = WordleConfig(
+//    filename = "words.txt",
+//    wordLength = 5,
+//    numberOfGuesses = 6
+//  )
+//  private val fileReader:        FileReader                    = WordsReader
+//  private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord
+//  private val guessConnector:    GuessInputConnector           = mock[GuessInputConnector]
+//
+//  "Wordle" should {
+//    "handle a player winning the game" when {
+//      "in all possible numbers of guesses" in {
+//        List(
+//          List(targetWord),
+//          List("CLEAN", targetWord),
+//          List("ELDER", "CLEAN", targetWord),
+//          List("HORSE", "ELDER", "CLEAN", targetWord),
+//          List("GREEN", "HORSE", "ELDER", "CLEAN", targetWord),
+//          List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", targetWord)
+//        ).foreach { userInputGuesses =>
+//          withClue(s"for guesses $userInputGuesses") {
+//            val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
+//            mockUserInputGuesses(userInputGuesses)
+//            wordle.startGame()
+//          }
+//        }
+//      }
+//    }
+//
+//    "handle a player losing the game" when {
+//      "each guess is valid" in {
+//        val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
+//        mockUserInputGuesses(List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN"))
+//        wordle.startGame()
+//      }
+//
+//      "some guesses are the wrong number of letters, include special characters or are not valid words" in {
+//        val wordle                  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
+//        val specialCharacterGuesses = List("&&&&&", "+++++", "%%%%%")
+//        val nonLetterGuesses        = List("12345", "ABC12")
+//        val wrongLengthGuesses      = List("", "ABC", "TESTING")
+//        val invalidWordGuesses      = List("AAAAA", "BBBBB", "CCCCC")
+//        val validGuesses            = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
+//        val invalidGuesses          = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
+//        mockUserInputGuesses(invalidGuesses ::: validGuesses)
+//        wordle.startGame()
+//      }
+//    }
+//  }
+//
+//  private def mockUserInputGuesses(guesses: List[String]): Unit =
+//    guesses.foreach((guessConnector.getUserInput _).expects().returns(_))
+//
+//}

--- a/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
@@ -24,6 +24,7 @@ final class WordleTest extends AnyWordSpecLike with Matchers {
    * the end state (no more guesses are requested for user input).
    */
   private def guessConnector(guesses: List[String]): GuessInputConnector = new GuessInputConnector {
+    @SuppressWarnings(Array("DisableSyntax.var"))
     var index = 0
     override def getUserInput: String = {
       val guess = guesses(index)

--- a/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
@@ -1,67 +1,74 @@
-//package com.tcooling.wordle.game
-//
-//import cats.data.NonEmptySet
-//import com.tcooling.wordle.input.GuessInputConnector
-//import com.tcooling.wordle.model.WordleConfig
-//import com.tcooling.wordle.parser.{FileReader, WordsReader}
-//import org.scalamock.scalatest.MockFactory
-//import org.scalatest.wordspec.AnyWordSpecLike
-//import org.scalatest.Matchers
-//
-//final class WordleTest extends AnyWordSpecLike with Matchers with MockFactory {
-//
-//  private val targetWord: String = "VAGUE"
-//  private val config: WordleConfig = WordleConfig(
-//    filename = "words.txt",
-//    wordLength = 5,
-//    numberOfGuesses = 6
-//  )
-//  private val fileReader:        FileReader                    = WordsReader
-//  private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord
-//  private val guessConnector:    GuessInputConnector           = mock[GuessInputConnector]
-//
-//  "Wordle" should {
-//    "handle a player winning the game" when {
-//      "in all possible numbers of guesses" in {
-//        List(
-//          List(targetWord),
-//          List("CLEAN", targetWord),
-//          List("ELDER", "CLEAN", targetWord),
-//          List("HORSE", "ELDER", "CLEAN", targetWord),
-//          List("GREEN", "HORSE", "ELDER", "CLEAN", targetWord),
-//          List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", targetWord)
-//        ).foreach { userInputGuesses =>
-//          withClue(s"for guesses $userInputGuesses") {
-//            val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-//            mockUserInputGuesses(userInputGuesses)
-//            wordle.startGame()
-//          }
-//        }
-//      }
-//    }
-//
-//    "handle a player losing the game" when {
-//      "each guess is valid" in {
-//        val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-//        mockUserInputGuesses(List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN"))
-//        wordle.startGame()
-//      }
-//
-//      "some guesses are the wrong number of letters, include special characters or are not valid words" in {
-//        val wordle                  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector)
-//        val specialCharacterGuesses = List("&&&&&", "+++++", "%%%%%")
-//        val nonLetterGuesses        = List("12345", "ABC12")
-//        val wrongLengthGuesses      = List("", "ABC", "TESTING")
-//        val invalidWordGuesses      = List("AAAAA", "BBBBB", "CCCCC")
-//        val validGuesses            = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
-//        val invalidGuesses          = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
-//        mockUserInputGuesses(invalidGuesses ::: validGuesses)
-//        wordle.startGame()
-//      }
-//    }
-//  }
-//
-//  private def mockUserInputGuesses(guesses: List[String]): Unit =
-//    guesses.foreach((guessConnector.getUserInput _).expects().returns(_))
-//
-//}
+package com.tcooling.wordle.game
+
+import cats.data.NonEmptySet
+import com.tcooling.wordle.input.GuessInputConnector
+import com.tcooling.wordle.model.WordleConfig
+import com.tcooling.wordle.parser.{FileReader, WordsReader}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
+
+final class WordleTest extends AnyWordSpecLike with Matchers {
+
+  private val targetWord: String = "VAGUE"
+  private val config: WordleConfig = WordleConfig(
+    filename = "words.txt",
+    wordLength = 5,
+    numberOfGuesses = 6
+  )
+  private val fileReader:        FileReader                    = WordsReader
+  private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord
+
+  /**
+   * An out of bounds exception will be thrown if the next index in the list does not exist, meaning the tests will
+   * fail if the [[GuessInputConnector]] is called when not supposed to be called. Basically, asserting that the FSM
+   * reaches the end state (no more guesses are requested for user input).
+   */
+  private def guessConnector(guesses: List[String]): GuessInputConnector = new GuessInputConnector {
+    var index = 0
+    override def getUserInput(): String = {
+      val guess = guesses(index)
+      index += 1
+      guess
+    }
+  }
+
+  "Wordle" should {
+    "handle a player winning the game" when {
+      "in all possible numbers of guesses" in {
+        List(
+          List(targetWord),
+          List("CLEAN", targetWord),
+          List("ELDER", "CLEAN", targetWord),
+          List("HORSE", "ELDER", "CLEAN", targetWord),
+          List("GREEN", "HORSE", "ELDER", "CLEAN", targetWord),
+          List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", targetWord)
+        ).foreach { userInputGuesses =>
+          withClue(s"for guesses $userInputGuesses") {
+            val wordle = new Wordle(config, fileReader, chooseRandomWordF, guessConnector(userInputGuesses))
+            wordle.startGame()
+          }
+        }
+      }
+    }
+
+    "handle a player losing the game" when {
+      "each guess is valid" in {
+        val guesses = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
+        val wordle  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector(guesses))
+        wordle.startGame()
+      }
+
+      "some guesses are the wrong number of letters, include special characters or are not valid words" in {
+        val specialCharacterGuesses = List("&&&&&", "+++++", "%%%%%")
+        val nonLetterGuesses        = List("12345", "ABC12")
+        val wrongLengthGuesses      = List("", "ABC", "TESTING")
+        val invalidWordGuesses      = List("AAAAA", "BBBBB", "CCCCC")
+        val validGuesses            = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
+        val invalidGuesses          = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
+        val guesses                 = invalidGuesses ::: validGuesses
+        val wordle                  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector(guesses))
+        wordle.startGame()
+      }
+    }
+  }
+}

--- a/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
@@ -15,17 +15,17 @@ final class WordleTest extends AnyWordSpecLike with Matchers {
     wordLength = 5,
     numberOfGuesses = 6
   )
-  private val fileReader:        FileReader                    = WordsReader
+  private val fileReader: FileReader                           = WordsReader
   private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord
 
   /**
-   * An out of bounds exception will be thrown if the next index in the list does not exist, meaning the tests will
-   * fail if the [[GuessInputConnector]] is called when not supposed to be called. Basically, asserting that the FSM
-   * reaches the end state (no more guesses are requested for user input).
+   * An out of bounds exception will be thrown if the next index in the list does not exist, meaning the tests will fail
+   * if the [[GuessInputConnector]] is called when not supposed to be called. Basically, asserting that the FSM reaches
+   * the end state (no more guesses are requested for user input).
    */
   private def guessConnector(guesses: List[String]): GuessInputConnector = new GuessInputConnector {
     var index = 0
-    override def getUserInput(): String = {
+    override def getUserInput: String = {
       val guess = guesses(index)
       index += 1
       guess
@@ -64,9 +64,9 @@ final class WordleTest extends AnyWordSpecLike with Matchers {
         val wrongLengthGuesses      = List("", "ABC", "TESTING")
         val invalidWordGuesses      = List("AAAAA", "BBBBB", "CCCCC")
         val validGuesses            = List("HELLO", "GREEN", "HORSE", "ELDER", "CLEAN", "CLOWN")
-        val invalidGuesses          = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
-        val guesses                 = invalidGuesses ::: validGuesses
-        val wordle                  = new Wordle(config, fileReader, chooseRandomWordF, guessConnector(guesses))
+        val invalidGuesses = specialCharacterGuesses ::: nonLetterGuesses ::: wrongLengthGuesses ::: invalidWordGuesses
+        val guesses        = invalidGuesses ::: validGuesses
+        val wordle         = new Wordle(config, fileReader, chooseRandomWordF, guessConnector(guesses))
         wordle.startGame()
       }
     }

--- a/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
+++ b/src/test/scala/com/tcooling/wordle/game/WordleTest.scala
@@ -2,7 +2,7 @@ package com.tcooling.wordle.game
 
 import cats.data.NonEmptySet
 import com.tcooling.wordle.input.GuessInputConnector
-import com.tcooling.wordle.model.WordleConfig
+import com.tcooling.wordle.model.{Filename, NumberOfGuesses, WordLength, WordleConfig}
 import com.tcooling.wordle.parser.{FileReader, WordsReader}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -11,9 +11,9 @@ final class WordleTest extends AnyWordSpecLike with Matchers {
 
   private val targetWord: String = "VAGUE"
   private val config: WordleConfig = WordleConfig(
-    filename = "words.txt",
-    wordLength = 5,
-    numberOfGuesses = 6
+    filename = Filename.apply("words.txt"),
+    wordLength = WordLength.apply(5),
+    numberOfGuesses = NumberOfGuesses.apply(6)
   )
   private val fileReader: FileReader                           = WordsReader
   private val chooseRandomWordF: NonEmptySet[String] => String = _ => targetWord

--- a/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
@@ -2,9 +2,10 @@ package com.tcooling.wordle.model
 
 import cats.implicits.toShow
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class LetterGuessTest extends WordSpecLike with Matchers {
+final class LetterGuessTest extends AnyWordSpecLike with Matchers {
 
   private val red:    String = Console.RED
   private val yellow: String = Console.YELLOW

--- a/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
@@ -7,10 +7,10 @@ import org.scalatest.matchers.should.Matchers
 
 final class LetterGuessTest extends AnyWordSpecLike with Matchers {
 
-  private val red:    String = Console.RED
+  private val red: String    = Console.RED
   private val yellow: String = Console.YELLOW
-  private val green:  String = Console.GREEN
-  private val reset:  String = Console.RESET
+  private val green: String  = Console.GREEN
+  private val reset: String  = Console.RESET
 
   "LetterGuess" should {
     "show a letter in the corresponding colour" when {

--- a/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/LetterGuessTest.scala
@@ -30,5 +30,4 @@ final class LetterGuessTest extends AnyWordSpecLike with Matchers {
       }
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
@@ -2,9 +2,10 @@ package com.tcooling.wordle.model
 
 import cats.implicits.toShow
 import com.tcooling.wordle.model.UserInputError.{IncorrectLength, NonLetterCharacter, WordDoesNotExist, showUserInputError}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class UserInputErrorTest extends WordSpecLike with Matchers {
+final class UserInputErrorTest extends AnyWordSpecLike with Matchers {
 
   private val blue:  String = Console.BLUE
   private val reset: String = Console.RESET

--- a/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
@@ -1,13 +1,18 @@
 package com.tcooling.wordle.model
 
 import cats.implicits.toShow
-import com.tcooling.wordle.model.UserInputError.{IncorrectLength, NonLetterCharacter, WordDoesNotExist, showUserInputError}
+import com.tcooling.wordle.model.UserInputError.{
+  showUserInputError,
+  IncorrectLength,
+  NonLetterCharacter,
+  WordDoesNotExist
+}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
 final class UserInputErrorTest extends AnyWordSpecLike with Matchers {
 
-  private val blue:  String = Console.BLUE
+  private val blue: String  = Console.BLUE
   private val reset: String = Console.RESET
 
   "UserInputError" should {

--- a/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/UserInputErrorTest.scala
@@ -20,5 +20,4 @@ final class UserInputErrorTest extends AnyWordSpecLike with Matchers {
       }
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
@@ -31,7 +31,8 @@ final class WordGuessTest extends AnyWordSpecLike with Matchers {
 
       "none of the letters from the input word match the target word" in {
         val allLettersIncorrectGuess = "CLICK"
-        WordGuess(allLettersIncorrectGuess, targetWord) shouldBe WordGuess(allLettersIncorrectGuess.map(IncorrectGuess.apply).toList)
+        WordGuess(allLettersIncorrectGuess, targetWord) shouldBe WordGuess(
+          allLettersIncorrectGuess.map(IncorrectGuess.apply).toList)
       }
     }
 

--- a/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
@@ -39,5 +39,4 @@ final class WordGuessTest extends AnyWordSpecLike with Matchers {
       WordGuess(targetWord.map(IncorrectGuess.apply).toList).show shouldBe targetWord
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
@@ -3,16 +3,17 @@ package com.tcooling.wordle.model
 import cats.implicits.toShow
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.model.WordGuess.showWordGuess
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class WordGuessTest extends WordSpecLike with Matchers {
+final class WordGuessTest extends AnyWordSpecLike with Matchers {
 
   private val targetWord: String = "VAGUE"
 
   "WordGuess" should {
     "be created from a target word and a user input word" when {
       "the words are the same" in {
-        WordGuess(targetWord, targetWord) shouldBe WordGuess(targetWord.map(CorrectGuess).toList)
+        WordGuess(targetWord, targetWord) shouldBe WordGuess(targetWord.map(CorrectGuess.apply).toList)
       }
 
       "some of the letters from the input word are in the target word, but in the wrong position" in {
@@ -30,12 +31,12 @@ final class WordGuessTest extends WordSpecLike with Matchers {
 
       "none of the letters from the input word match the target word" in {
         val allLettersIncorrectGuess = "CLICK"
-        WordGuess(allLettersIncorrectGuess, targetWord) shouldBe WordGuess(allLettersIncorrectGuess.map(IncorrectGuess).toList)
+        WordGuess(allLettersIncorrectGuess, targetWord) shouldBe WordGuess(allLettersIncorrectGuess.map(IncorrectGuess.apply).toList)
       }
     }
 
     "show a word guess" in {
-      WordGuess(targetWord.map(IncorrectGuess).toList).show shouldBe targetWord
+      WordGuess(targetWord.map(IncorrectGuess.apply).toList).show shouldBe targetWord
     }
   }
 

--- a/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
+++ b/src/test/scala/com/tcooling/wordle/model/WordGuessTest.scala
@@ -1,6 +1,7 @@
 package com.tcooling.wordle.model
 
 import cats.implicits.toShow
+import com.tcooling.wordle.model.TargetWord
 import com.tcooling.wordle.model.LetterGuess.{CorrectGuess, IncorrectGuess, WrongPositionGuess}
 import com.tcooling.wordle.model.WordGuess.showWordGuess
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -8,12 +9,12 @@ import org.scalatest.matchers.should.Matchers
 
 final class WordGuessTest extends AnyWordSpecLike with Matchers {
 
-  private val targetWord: String = "VAGUE"
+  private val targetWord: TargetWord = TargetWord.apply("VAGUE")
 
   "WordGuess" should {
     "be created from a target word and a user input word" when {
       "the words are the same" in {
-        WordGuess(targetWord, targetWord) shouldBe WordGuess(targetWord.map(CorrectGuess.apply).toList)
+        WordGuess(targetWord.value, targetWord) shouldBe WordGuess(targetWord.value.map(CorrectGuess.apply).toList)
       }
 
       "some of the letters from the input word are in the target word, but in the wrong position" in {
@@ -37,7 +38,7 @@ final class WordGuessTest extends AnyWordSpecLike with Matchers {
     }
 
     "show a word guess" in {
-      WordGuess(targetWord.map(IncorrectGuess.apply).toList).show shouldBe targetWord
+      WordGuess(targetWord.value.map(IncorrectGuess.apply).toList).show shouldBe targetWord.value
     }
   }
 }

--- a/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
@@ -3,9 +3,10 @@ package com.tcooling.wordle.parser
 import cats.data.{NonEmptyList, NonEmptySet}
 import com.tcooling.wordle.model.UserInputError
 import com.tcooling.wordle.model.UserInputError.{IncorrectLength, NonLetterCharacter, WordDoesNotExist}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class UserInputParserTest extends WordSpecLike with Matchers {
+final class UserInputParserTest extends AnyWordSpecLike with Matchers {
 
   private val wordLength: Int                 = 5
   private val allWords:   NonEmptySet[String] = NonEmptyList.of(head = "VAGUE", tail = "CLICK").toNes

--- a/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
@@ -8,10 +8,11 @@ import org.scalatest.matchers.should.Matchers
 
 final class UserInputParserTest extends AnyWordSpecLike with Matchers {
 
-  private val wordLength: Int                 = 5
-  private val allWords:   NonEmptySet[String] = NonEmptyList.of(head = "VAGUE", tail = "CLICK").toNes
+  private val wordLength: Int               = 5
+  private val allWords: NonEmptySet[String] = NonEmptyList.of(head = "VAGUE", tail = "CLICK").toNes
 
-  private val parseGuessF: String => Either[UserInputError, String] = UserInputParser.parseGuess(allWords, _, wordLength)
+  private val parseGuessF: String => Either[UserInputError, String] =
+    UserInputParser.parseGuess(allWords, _, wordLength)
 
   "UserInputParser" should {
     "parse valid user input" when {

--- a/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
@@ -1,14 +1,14 @@
 package com.tcooling.wordle.parser
 
 import cats.data.{NonEmptyList, NonEmptySet}
-import com.tcooling.wordle.model.UserInputError
+import com.tcooling.wordle.model.{UserInputError, WordLength}
 import com.tcooling.wordle.model.UserInputError.{IncorrectLength, NonLetterCharacter, WordDoesNotExist}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
 final class UserInputParserTest extends AnyWordSpecLike with Matchers {
 
-  private val wordLength: Int               = 5
+  private val wordLength: WordLength        = WordLength.apply(5)
   private val allWords: NonEmptySet[String] = NonEmptyList.of(head = "VAGUE", tail = "CLICK").toNes
 
   private val parseGuessF: String => Either[UserInputError, String] =
@@ -28,15 +28,15 @@ final class UserInputParserTest extends AnyWordSpecLike with Matchers {
     "parse invalid user input" when {
       "the length is not equal to 5" when {
         "too long" in {
-          parseGuessF("BOTTLE") shouldBe Left(IncorrectLength(wordLength))
+          parseGuessF("BOTTLE") shouldBe Left(IncorrectLength(wordLength.value))
         }
 
         "too short" in {
-          parseGuessF("THE") shouldBe Left(IncorrectLength(wordLength))
+          parseGuessF("THE") shouldBe Left(IncorrectLength(wordLength.value))
         }
 
         "empty" in {
-          parseGuessF("") shouldBe Left(IncorrectLength(wordLength))
+          parseGuessF("") shouldBe Left(IncorrectLength(wordLength.value))
         }
       }
 

--- a/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/UserInputParserTest.scala
@@ -54,5 +54,4 @@ final class UserInputParserTest extends AnyWordSpecLike with Matchers {
       }
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/parser/WordRegexTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordRegexTest.scala
@@ -31,5 +31,4 @@ final class WordRegexTest extends AnyWordSpecLike with Matchers {
       }
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/parser/WordRegexTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordRegexTest.scala
@@ -1,8 +1,9 @@
 package com.tcooling.wordle.parser
 
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
-final class WordRegexTest extends WordSpecLike with Matchers {
+final class WordRegexTest extends AnyWordSpecLike with Matchers {
 
   private val onSuccess: String = "onSuccess"
   private val onFailure: String = "onFailure"

--- a/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
@@ -1,76 +1,77 @@
-package com.tcooling.wordle.parser
-
-import cats.data.NonEmptySet
-import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpecLike}
-
-import scala.util.{Failure, Success}
-
-final class WordsParserTest extends WordSpecLike with Matchers with MockFactory {
-
-  private val fileReader: FileReader = mock[FileReader]
-  private val filename:   String     = "someWordsFile.txt"
-  private val wordLength: Int        = 5
-
-  "WordsParser" should {
-    "parse valid words input" when {
-      "there is only one word" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("hello")))
-        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO"))
-      }
-
-      "there are many words" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "world", "horse", "robot")))
-        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
-      }
-
-      "some words are capitalised" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "WORLD", "HORSE", "robot")))
-        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
-      }
-
-      "some words are of incorrect length" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("hell", "world", "horse", "helloo")))
-        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
-      }
-
-      "some words have non letter characters" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("hell-", "world", "horse", "hell&")))
-        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
-      }
-    }
-
-    "return an error" when {
-      "the file reader cannot read the file" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Failure(new RuntimeException("Cannot parse file")))
-        parser.parseWords shouldBe Left(FileParseError)
-      }
-
-      "no words are present" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List()))
-        parser.parseWords shouldBe Left(EmptyFileError)
-      }
-
-      "all the words are of incorrect length" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("h", "he", "hell", "helloo")))
-        parser.parseWords shouldBe Left(InvalidWordsError)
-      }
-
-      "all the words include non letter characters" in {
-        val parser = WordsParser(filename, wordLength, fileReader)
-        (fileReader.getLines _).expects(filename).returning(Success(List("12345", "hell&", "^^", "hell0")))
-        parser.parseWords shouldBe Left(InvalidWordsError)
-      }
-    }
-  }
-
-}
+//package com.tcooling.wordle.parser
+//
+//import cats.data.NonEmptySet
+//import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
+//import org.scalamock.scalatest.MockFactory
+//import org.scalatest.wordspec.AnyWordSpecLike
+//import org.scalatest.matchers.should.Matchers
+//
+//import scala.util.{Failure, Success}
+//
+//final class WordsParserTest extends AnyWordSpecLike with Matchers with MockFactory {
+//
+//  private val fileReader: FileReader = mock[FileReader]
+//  private val filename:   String     = "someWordsFile.txt"
+//  private val wordLength: Int        = 5
+//
+//  "WordsParser" should {
+//    "parse valid words input" when {
+//      "there is only one word" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("hello")))
+//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO"))
+//      }
+//
+//      "there are many words" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "world", "horse", "robot")))
+//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
+//      }
+//
+//      "some words are capitalised" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "WORLD", "HORSE", "robot")))
+//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
+//      }
+//
+//      "some words are of incorrect length" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("hell", "world", "horse", "helloo")))
+//        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
+//      }
+//
+//      "some words have non letter characters" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("hell-", "world", "horse", "hell&")))
+//        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
+//      }
+//    }
+//
+//    "return an error" when {
+//      "the file reader cannot read the file" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Failure(new RuntimeException("Cannot parse file")))
+//        parser.parseWords shouldBe Left(FileParseError)
+//      }
+//
+//      "no words are present" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List()))
+//        parser.parseWords shouldBe Left(EmptyFileError)
+//      }
+//
+//      "all the words are of incorrect length" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("h", "he", "hell", "helloo")))
+//        parser.parseWords shouldBe Left(InvalidWordsError)
+//      }
+//
+//      "all the words include non letter characters" in {
+//        val parser = WordsParser(filename, wordLength, fileReader)
+//        (fileReader.getLines _).expects(filename).returning(Success(List("12345", "hell&", "^^", "hell0")))
+//        parser.parseWords shouldBe Left(InvalidWordsError)
+//      }
+//    }
+//  }
+//
+//}

--- a/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
@@ -11,6 +11,8 @@ import scala.util.{Failure, Success, Try}
 final class WordsParserTest extends AnyWordSpecLike with Matchers {
 
   private val filename: Filename = Filename.apply("someWordsFile.txt")
+
+  @SuppressWarnings(Array("DisableSyntax.throw"))
   private def fileReader(expectedFilename: Filename, linesTry: Try[List[String]]): FileReader = (filename: Filename) =>
     if (filename == expectedFilename) {
       linesTry

--- a/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
@@ -1,77 +1,69 @@
-//package com.tcooling.wordle.parser
-//
-//import cats.data.NonEmptySet
-//import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
-//import org.scalamock.scalatest.MockFactory
-//import org.scalatest.wordspec.AnyWordSpecLike
-//import org.scalatest.matchers.should.Matchers
-//
-//import scala.util.{Failure, Success}
-//
-//final class WordsParserTest extends AnyWordSpecLike with Matchers with MockFactory {
-//
-//  private val fileReader: FileReader = mock[FileReader]
-//  private val filename:   String     = "someWordsFile.txt"
-//  private val wordLength: Int        = 5
-//
-//  "WordsParser" should {
-//    "parse valid words input" when {
-//      "there is only one word" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("hello")))
-//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO"))
-//      }
-//
-//      "there are many words" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "world", "horse", "robot")))
-//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
-//      }
-//
-//      "some words are capitalised" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("hello", "WORLD", "HORSE", "robot")))
-//        parser.parseWords shouldBe Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
-//      }
-//
-//      "some words are of incorrect length" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("hell", "world", "horse", "helloo")))
-//        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
-//      }
-//
-//      "some words have non letter characters" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("hell-", "world", "horse", "hell&")))
-//        parser.parseWords shouldBe Right(NonEmptySet.of("WORLD", "HORSE"))
-//      }
-//    }
-//
-//    "return an error" when {
-//      "the file reader cannot read the file" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Failure(new RuntimeException("Cannot parse file")))
-//        parser.parseWords shouldBe Left(FileParseError)
-//      }
-//
-//      "no words are present" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List()))
-//        parser.parseWords shouldBe Left(EmptyFileError)
-//      }
-//
-//      "all the words are of incorrect length" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("h", "he", "hell", "helloo")))
-//        parser.parseWords shouldBe Left(InvalidWordsError)
-//      }
-//
-//      "all the words include non letter characters" in {
-//        val parser = WordsParser(filename, wordLength, fileReader)
-//        (fileReader.getLines _).expects(filename).returning(Success(List("12345", "hell&", "^^", "hell0")))
-//        parser.parseWords shouldBe Left(InvalidWordsError)
-//      }
-//    }
-//  }
-//
-//}
+package com.tcooling.wordle.parser
+
+import cats.data.NonEmptySet
+import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.{Failure, Success, Try}
+
+final class WordsParserTest extends AnyWordSpecLike with Matchers {
+
+  private val filename: String = "someWordsFile.txt"
+  private def fileReader(expectedFilename: String, linesTry: Try[List[String]]): FileReader = (filename: String) =>
+    if (filename == expectedFilename) {
+      linesTry
+    } else throw new RuntimeException("Filename does not match")
+
+  private val fileReaderF: Try[List[String]] => FileReader = fileReader(filename, _)
+  private val wordLength:  Int                             = 5
+
+  private def wordsParser(linesTry: Try[List[String]]): WordsParser =
+    WordsParser(filename, wordLength, fileReaderF(linesTry))
+
+  "WordsParser" should {
+    "parse valid words input" when {
+      "there is only one word" in {
+        wordsParser(Success(List("hello"))).parseWords shouldBe Right(NonEmptySet.of("HELLO"))
+      }
+
+      "there are many words" in {
+        wordsParser(Success(List("hello", "world", "horse", "robot"))).parseWords shouldBe
+          Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
+      }
+
+      "some words are capitalised" in {
+        wordsParser(Success(List("hello", "WORLD", "HORSE", "robot"))).parseWords shouldBe
+          Right(NonEmptySet.of("HELLO", "WORLD", "HORSE", "ROBOT"))
+      }
+
+      "some words are of incorrect length" in {
+        wordsParser(Success(List("hell", "world", "horse", "helloo"))).parseWords shouldBe
+          Right(NonEmptySet.of("WORLD", "HORSE"))
+      }
+
+      "some words have non letter characters" in {
+        wordsParser(Success(List("hell-", "world", "horse", "hell&"))).parseWords shouldBe
+          Right(NonEmptySet.of("WORLD", "HORSE"))
+      }
+    }
+
+    "return an error" when {
+      "the file reader cannot read the file" in {
+        wordsParser(Failure(new RuntimeException("Cannot parse file"))).parseWords shouldBe Left(FileParseError)
+      }
+
+      "no words are present" in {
+        wordsParser(Success(List())).parseWords shouldBe Left(EmptyFileError)
+      }
+
+      "all the words are of incorrect length" in {
+        wordsParser(Success(List("h", "he", "hell", "helloo"))).parseWords shouldBe Left(InvalidWordsError)
+      }
+
+      "all the words include non letter characters" in {
+        wordsParser(Success(List("12345", "hell&", "^^", "hell0"))).parseWords shouldBe Left(InvalidWordsError)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
@@ -16,7 +16,7 @@ final class WordsParserTest extends AnyWordSpecLike with Matchers {
     } else throw new RuntimeException("Filename does not match")
 
   private val fileReaderF: Try[List[String]] => FileReader = fileReader(filename, _)
-  private val wordLength:  Int                             = 5
+  private val wordLength: Int                              = 5
 
   private def wordsParser(linesTry: Try[List[String]]): WordsParser =
     WordsParser(filename, wordLength, fileReaderF(linesTry))

--- a/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsParserTest.scala
@@ -1,6 +1,7 @@
 package com.tcooling.wordle.parser
 
 import cats.data.NonEmptySet
+import com.tcooling.wordle.model.{Filename, WordLength}
 import com.tcooling.wordle.model.WordsParserError.{EmptyFileError, FileParseError, InvalidWordsError}
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -9,14 +10,14 @@ import scala.util.{Failure, Success, Try}
 
 final class WordsParserTest extends AnyWordSpecLike with Matchers {
 
-  private val filename: String = "someWordsFile.txt"
-  private def fileReader(expectedFilename: String, linesTry: Try[List[String]]): FileReader = (filename: String) =>
+  private val filename: Filename = Filename.apply("someWordsFile.txt")
+  private def fileReader(expectedFilename: Filename, linesTry: Try[List[String]]): FileReader = (filename: Filename) =>
     if (filename == expectedFilename) {
       linesTry
     } else throw new RuntimeException("Filename does not match")
 
   private val fileReaderF: Try[List[String]] => FileReader = fileReader(filename, _)
-  private val wordLength: Int                              = 5
+  private val wordLength: WordLength                       = WordLength.apply(5)
 
   private def wordsParser(linesTry: Try[List[String]]): WordsParser =
     WordsParser(filename, wordLength, fileReaderF(linesTry))

--- a/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
@@ -1,10 +1,11 @@
 package com.tcooling.wordle.parser
 
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
-final class WordsReaderTest extends WordSpecLike with Matchers {
+final class WordsReaderTest extends AnyWordSpecLike with Matchers {
 
   "WordsReader" should {
     "read a valid file and return a list of lines" in {

--- a/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
@@ -21,5 +21,4 @@ final class WordsReaderTest extends AnyWordSpecLike with Matchers {
       WordsReader.getLines(filename = "fileDoesNotExist.txt").isFailure shouldBe true
     }
   }
-
 }

--- a/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
+++ b/src/test/scala/com/tcooling/wordle/parser/WordsReaderTest.scala
@@ -1,5 +1,6 @@
 package com.tcooling.wordle.parser
 
+import com.tcooling.wordle.model.Filename
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -9,7 +10,7 @@ final class WordsReaderTest extends AnyWordSpecLike with Matchers {
 
   "WordsReader" should {
     "read a valid file and return a list of lines" in {
-      WordsReader.getLines(filename = "validFile.txt") shouldBe Success(
+      WordsReader.getLines(filename = Filename.apply("validFile.txt")) shouldBe Success(
         List(
           "hello",
           "world"
@@ -18,7 +19,7 @@ final class WordsReaderTest extends AnyWordSpecLike with Matchers {
     }
 
     "throw an exception for a file that does not exist" in {
-      WordsReader.getLines(filename = "fileDoesNotExist.txt").isFailure shouldBe true
+      WordsReader.getLines(filename = Filename.apply("fileDoesNotExist.txt")).isFailure shouldBe true
     }
   }
 }


### PR DESCRIPTION
Migrate to Scala 3 version `3.3.1` and set sbt version to `1.9.7`. Implement the following Scala 3 changes:
- new scalafix/scalafmt config
- remove use of Mockito, replace with own implementations in tests
- use enum for `FSM` and `WordsParserError`
- add extension method for creating the board row from a `WordGuess`
- use `*` for imports
- use trait with parameter instead of `sealed abstract class`
- use opaque types for `TargetWord`, `Filename`, `WordLength` and `NumberOfGuesses` 